### PR TITLE
Fix: harden catalog parsing, cell ids, and tilestr parsers against bad input

### DIFF
--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -40,6 +40,22 @@ func main() {
 		*workers = 1
 	}
 
+	// The scale table (mercantile.Scale) is defined for z0..z23; beyond it the
+	// SCAMIN/SCAMAX filtering degrades, so clamp explicit flags into range.
+	const maxSupportedZoom = 23
+	clampZoom := func(name string, zp *int) {
+		switch {
+		case *zp < 0:
+			fmt.Printf("Note: -%s %d is below 0; clamped to 0.\n", name, *zp)
+			*zp = 0
+		case *zp > maxSupportedZoom:
+			fmt.Printf("Note: -%s %d exceeds the supported maximum z%d; clamped.\n", name, *zp, maxSupportedZoom)
+			*zp = maxSupportedZoom
+		}
+	}
+	clampZoom("minzoom", minzoom)
+	clampZoom("maxzoom", maxzoom)
+
 	// Honor explicit -minzoom/-maxzoom; otherwise the zoom range is derived per cell
 	// from its S-57 usage band (overview→berthing) in the pre-pass below.
 	userSetZoom := false
@@ -116,11 +132,21 @@ func main() {
 	fmt.Println("Scanning…")
 	var work []workUnit
 	var grandTotal int64
+	var reports []zoomReport
 	for _, ds := range datasets {
 		for _, file := range ds.Files {
 			fminzoom, fmaxzoom := *minzoom, *maxzoom
-			if !userSetZoom && tile == nil && bounds == nil {
-				fminzoom, fmaxzoom = dataset.BandZoom(dataset.UsageBand(file))
+			if tile == nil {
+				zr := dataset.CellZoomRange(file)
+				if !userSetZoom && bounds == nil {
+					fminzoom, fmaxzoom = zr.Min, zr.Max
+				}
+				reports = append(reports, zoomReport{
+					convMin:  fminzoom,
+					convMax:  fmaxzoom,
+					availMin: zr.Min,
+					availMax: zr.Max,
+				})
 			}
 			for z := fminzoom; z <= fmaxzoom; z++ {
 				var tiles map[string]m.TileID
@@ -141,6 +167,19 @@ func main() {
 			}
 		}
 	}
+
+	if lines, hint := summarizeZooms(reports); len(lines) > 0 {
+		fmt.Println("Zoom levels:")
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+		if hint != "" {
+			fmt.Println(hint)
+		}
+	}
+	// Print the grand total up front: a native-zoom run over large-scale charts
+	// can be very large, so surface the count before the (possibly long) tiling.
+	fmt.Printf("Generating %d tiles\n", grandTotal)
 
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()

--- a/cmd/s57-tiler/zoomsummary.go
+++ b/cmd/s57-tiler/zoomsummary.go
@@ -1,0 +1,86 @@
+package main
+
+import "fmt"
+
+// zoomReport records, for one cell, the zoom range that will be generated
+// (conv*) and the range the cell's data supports (avail*, the native detail
+// ceiling from the compilation scale).
+type zoomReport struct {
+	convMin, convMax   int
+	availMin, availMax int
+}
+
+// isSubset reports whether the converting range omits zoom levels the data
+// supports — finer detail above (convMax<availMax) or coarser views below
+// (convMin>availMin).
+func (r zoomReport) isSubset() bool {
+	return r.convMin > r.availMin || r.convMax < r.availMax
+}
+
+// summarizeZooms groups the reports by identical (converting, available) range
+// and returns one summary line per group plus a hint. The hint is empty unless
+// at least one cell omits available zoom levels; when present it names only the
+// flag(s) (-minzoom/-maxzoom) that would widen the range, using the envelope
+// across all subset cells. Groups are emitted in first-seen order, so output is
+// deterministic for a given input.
+func summarizeZooms(reports []zoomReport) (lines []string, hint string) {
+	if len(reports) == 0 {
+		return nil, ""
+	}
+
+	type group struct {
+		rep   zoomReport
+		count int
+	}
+	var order []string
+	groups := map[string]*group{}
+	for _, r := range reports {
+		key := fmt.Sprintf("%d-%d/%d-%d", r.convMin, r.convMax, r.availMin, r.availMax)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{rep: r}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.count++
+	}
+	for _, key := range order {
+		g := groups[key]
+		r := g.rep
+		line := fmt.Sprintf("  %d chart(s): converting z%d-z%d", g.count, r.convMin, r.convMax)
+		if r.isSubset() {
+			line += fmt.Sprintf("  (data available z%d-z%d)", r.availMin, r.availMax)
+		}
+		lines = append(lines, line)
+	}
+
+	minSubset, maxSubset := false, false
+	hintMin := int(^uint(0) >> 1)
+	hintMax := -1
+	for _, r := range reports {
+		if r.convMax < r.availMax {
+			maxSubset = true
+			if r.availMax > hintMax {
+				hintMax = r.availMax
+			}
+		}
+		if r.convMin > r.availMin {
+			minSubset = true
+			if r.availMin < hintMin {
+				hintMin = r.availMin
+			}
+		}
+	}
+	switch {
+	case minSubset && maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits detail some charts contain; "+
+			"pass -minzoom %d -maxzoom %d for their full native range (more tiles).", hintMin, hintMax)
+	case maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits finer detail some charts contain; "+
+			"pass -maxzoom %d to tile their full native range (more tiles).", hintMax)
+	case minSubset:
+		hint = fmt.Sprintf("The selected zoom omits coarser levels some charts cover; "+
+			"pass -minzoom %d to include them.", hintMin)
+	}
+	return lines, hint
+}

--- a/cmd/s57-tiler/zoomsummary_test.go
+++ b/cmd/s57-tiler/zoomsummary_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSummarizeZoomsSubsetHint: a group whose converting max is below its
+// available max is flagged as a subset, shows the available range, and triggers
+// a -maxzoom hint naming the envelope max. Identical ranges collapse to one line.
+func TestSummarizeZoomsSubsetHint(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // subset (max)
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // same group
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14}, // full range
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 grouped lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "2 chart(s)") || !strings.Contains(lines[0], "z12-z16") {
+		t.Errorf("group line 0 = %q, want 2 charts converting z12-z16", lines[0])
+	}
+	if !strings.Contains(lines[0], "available z12-z19") {
+		t.Errorf("subset line should show the available range, got %q", lines[0])
+	}
+	if strings.Contains(lines[1], "available") {
+		t.Errorf("full-range line should not show an available range, got %q", lines[1])
+	}
+	if hint == "" {
+		t.Fatal("expected a hint when a group is a subset")
+	}
+	if !strings.Contains(hint, "-maxzoom 19") {
+		t.Errorf("hint should suggest -maxzoom 19, got %q", hint)
+	}
+	if strings.Contains(hint, "-minzoom") {
+		t.Errorf("hint should not mention -minzoom when only the max is a subset, got %q", hint)
+	}
+}
+
+// TestSummarizeZoomsNoHintWhenFull: when every cell covers its full available
+// range, no hint is produced and no "available" suffix is shown.
+func TestSummarizeZoomsNoHintWhenFull(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14},
+		{convMin: 13, convMax: 17, availMin: 13, availMax: 17},
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if hint != "" {
+		t.Errorf("expected no hint when nothing is a subset, got %q", hint)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	for _, l := range lines {
+		if strings.Contains(l, "available") {
+			t.Errorf("full-range line should omit available, got %q", l)
+		}
+	}
+}
+
+// TestSummarizeZoomsMinSubset: a narrowed low end (override) yields a -minzoom hint.
+func TestSummarizeZoomsMinSubset(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 14, convMax: 16, availMin: 12, availMax: 16}, // subset (min only)
+	}
+	_, hint := summarizeZooms(reports)
+	if !strings.Contains(hint, "-minzoom 12") {
+		t.Errorf("hint should suggest -minzoom 12, got %q", hint)
+	}
+	if strings.Contains(hint, "-maxzoom") {
+		t.Errorf("hint should not mention -maxzoom when only the min is a subset, got %q", hint)
+	}
+}
+
+func TestSummarizeZoomsEmpty(t *testing.T) {
+	lines, hint := summarizeZooms(nil)
+	if lines != nil || hint != "" {
+		t.Errorf("empty input should give empty output, got lines=%v hint=%q", lines, hint)
+	}
+}

--- a/s57/dataset/dataset.go
+++ b/s57/dataset/dataset.go
@@ -94,6 +94,45 @@ func (dataset Dataset) GetDatasetForTile(tile m.TileID) Dataset {
 	return retVal
 }
 
+// catalogCellRef extracts a cell's .000 file name and human title from a catalog
+// DataRecord, bounds-checking every field/subfield access so a truncated or
+// unexpected record is skipped (ok=false) rather than panicking. The subfield
+// layout mirrors the S-57 catalog: index 2 = file name, 3 = title, 5 = record
+// type ("BIN" for the binary cell files we tile).
+func catalogCellRef(rec iso8211.DataRecord) (fileName, title string, ok bool) {
+	if len(rec.Fields) < 2 {
+		return "", "", false
+	}
+	sf := rec.Fields[1].SubFields
+	if len(sf) < 6 || sf[5] != "BIN" {
+		return "", "", false
+	}
+	fileName = fmt.Sprintf("%s", sf[2])
+	if !strings.Contains(fileName, ".000") {
+		return "", "", false
+	}
+	if len(sf) > 3 {
+		title = strings.TrimSpace(fmt.Sprintf("%s", sf[3]))
+	}
+	return fileName, title, true
+}
+
+// safeCellID derives the chart id from a cell file path (its base name minus the
+// ".000" suffix) and rejects anything that isn't a single, safe path element, so
+// a crafted catalog can't make the id (".."/"."/a separator/empty) escape the
+// output directory when it is later joined into the tile path.
+func safeCellID(filePath string) (string, bool) {
+	base := filepath.Base(filePath)
+	if len(base) < 4 {
+		return "", false
+	}
+	id := base[:len(base)-4]
+	if id == "" || id == "." || id == ".." || strings.ContainsAny(id, `/\`) {
+		return "", false
+	}
+	return id, true
+}
+
 func GetS57Datasets(path string) ([]Dataset, error) {
 	datasets := make([]Dataset, 0)
 	err := filepath.WalkDir(path, func(fp string, entry fs.DirEntry, err error) error {
@@ -113,37 +152,46 @@ func GetS57Datasets(path string) ([]Dataset, error) {
 				if err != nil {
 					return err
 				}
+				defer f.Close()
 				var l iso8211.LeadRecord
 				l.Read(f)
 				var d iso8211.DataRecord
 				d.Lead = &l
 				for d.Read(f) == nil {
-					if d.Fields[1].SubFields[5] == "BIN" {
-						fileName := fmt.Sprintf("%s", d.Fields[1].SubFields[2])
-						if strings.Contains(fileName, ".000") {
-							filePath := strings.ReplaceAll(fileName, "\\", string(os.PathSeparator))
-							filePath = filepath.Join(filepath.Dir(fp), filePath)
-							parts = strings.Split(filePath, string(os.PathSeparator))
-							datasource := gdal.OpenDataSource(filePath, 0)
-							defer datasource.Destroy()
-							// The catalog's LFIL ("long file name") subfield carries the
-							// cell's human-readable title (e.g. "Anacortes and Vicinity, WA"),
-							// used as the chart Description. Absent in some older downloads.
-							title := ""
-							if len(d.Fields[1].SubFields) > 3 {
-								title = strings.TrimSpace(fmt.Sprintf("%s", d.Fields[1].SubFields[3]))
-							}
-							file := File{
-								Id:     parts[len(parts)-1][0 : len(parts[len(parts)-1])-4],
-								Path:   filePath,
-								Title:  title,
-								Layers: getLayers(datasource),
-							}
-							dataset.Files = append(dataset.Files, file)
-						}
-
+					// The catalog's LFIL ("long file name") subfield carries the cell's
+					// human-readable title (e.g. "Anacortes and Vicinity, WA"), used as the
+					// chart Description; absent in some older downloads.
+					fileName, title, ok := catalogCellRef(d)
+					if !ok {
+						continue
 					}
-
+					filePath := strings.ReplaceAll(fileName, "\\", string(os.PathSeparator))
+					filePath = filepath.Join(filepath.Dir(fp), filePath)
+					cellID, ok := safeCellID(filePath)
+					if !ok {
+						fmt.Fprintf(os.Stderr, "skipping cell with unsafe name %q in %s\n", fileName, fp)
+						continue
+					}
+					// Skip cells the catalog references but that aren't present/readable,
+					// so a dangling entry never reaches OpenDataSource (whose binding can't
+					// report a failed open).
+					if _, statErr := os.Stat(filePath); statErr != nil {
+						fmt.Fprintf(os.Stderr, "skipping missing cell %s: %v\n", filePath, statErr)
+						continue
+					}
+					// Open, enumerate layers, and release the handle immediately rather
+					// than deferring (a deferred Destroy here would keep every cell in the
+					// catalog open until the whole walk returns, exhausting file descriptors
+					// on large catalogs).
+					datasource := gdal.OpenDataSource(filePath, 0)
+					layers := getLayers(datasource)
+					datasource.Destroy()
+					dataset.Files = append(dataset.Files, File{
+						Id:     cellID,
+						Path:   filePath,
+						Title:  title,
+						Layers: layers,
+					})
 				}
 				datasets = append(datasets, dataset)
 

--- a/s57/dataset/discovery_test.go
+++ b/s57/dataset/discovery_test.go
@@ -1,0 +1,88 @@
+package dataset
+
+import (
+	"testing"
+
+	"github.com/tburke/iso8211"
+)
+
+// field1 builds a catalog DataRecord whose Fields[1].SubFields are the given
+// values, mirroring the layout GetS57Datasets reads (index 2 = file name, 3 =
+// title, 5 = record type).
+func field1(subfields ...interface{}) iso8211.DataRecord {
+	return iso8211.DataRecord{Fields: []iso8211.Field{
+		{},
+		{SubFields: subfields},
+	}}
+}
+
+func TestCatalogCellRef(t *testing.T) {
+	cases := []struct {
+		name             string
+		rec              iso8211.DataRecord
+		wantFile         string
+		wantTitle        string
+		wantOK           bool
+	}{
+		{
+			name:      "valid BIN .000 row",
+			rec:       field1("0", "1", "ENC_ROOT/US4WA1JJ.000", "Anacortes, WA", "4", "BIN"),
+			wantFile:  "ENC_ROOT/US4WA1JJ.000",
+			wantTitle: "Anacortes, WA",
+			wantOK:    true,
+		},
+		{
+			name:   "not a BIN record",
+			rec:    field1("0", "1", "US4WA1JJ.000", "t", "4", "ASC"),
+			wantOK: false,
+		},
+		{
+			name:   "BIN but not a .000 cell",
+			rec:    field1("0", "1", "README.TXT", "t", "4", "BIN"),
+			wantOK: false,
+		},
+		{
+			name:   "too few subfields (truncated record)",
+			rec:    field1("0", "1", "US4WA1JJ.000"),
+			wantOK: false,
+		},
+		{
+			name:   "too few fields",
+			rec:    iso8211.DataRecord{Fields: []iso8211.Field{{}}},
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotFile, gotTitle, ok := catalogCellRef(c.rec)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if ok && (gotFile != c.wantFile || gotTitle != c.wantTitle) {
+				t.Errorf("got (%q,%q), want (%q,%q)", gotFile, gotTitle, c.wantFile, c.wantTitle)
+			}
+		})
+	}
+}
+
+func TestSafeCellID(t *testing.T) {
+	cases := []struct {
+		path   string
+		wantID string
+		wantOK bool
+	}{
+		{"/data/ENC_ROOT/US4WA1JJ.000", "US4WA1JJ", true},
+		{"/data/1R7WAD01.000", "1R7WAD01", true},
+		{"deep/dir/B.000", "B", true},   // a dir separator in the path is fine; the id is the base
+		{"/data/...000", "", false},     // id would be ".."  -> traversal
+		{"/data/..000", "", false},      // id would be "."
+		{"/data/.000", "", false},       // id would be empty
+		{"/data/ab", "", false},         // shorter than the ".000" suffix
+	}
+	for _, c := range cases {
+		got, ok := safeCellID(c.path)
+		if ok != c.wantOK || (ok && got != c.wantID) {
+			t.Errorf("safeCellID(%q) = (%q,%v), want (%q,%v)", c.path, got, ok, c.wantID, c.wantOK)
+		}
+	}
+}

--- a/s57/dataset/discovery_test.go
+++ b/s57/dataset/discovery_test.go
@@ -18,11 +18,11 @@ func field1(subfields ...interface{}) iso8211.DataRecord {
 
 func TestCatalogCellRef(t *testing.T) {
 	cases := []struct {
-		name             string
-		rec              iso8211.DataRecord
-		wantFile         string
-		wantTitle        string
-		wantOK           bool
+		name      string
+		rec       iso8211.DataRecord
+		wantFile  string
+		wantTitle string
+		wantOK    bool
 	}{
 		{
 			name:      "valid BIN .000 row",
@@ -73,11 +73,11 @@ func TestSafeCellID(t *testing.T) {
 	}{
 		{"/data/ENC_ROOT/US4WA1JJ.000", "US4WA1JJ", true},
 		{"/data/1R7WAD01.000", "1R7WAD01", true},
-		{"deep/dir/B.000", "B", true},   // a dir separator in the path is fine; the id is the base
-		{"/data/...000", "", false},     // id would be ".."  -> traversal
-		{"/data/..000", "", false},      // id would be "."
-		{"/data/.000", "", false},       // id would be empty
-		{"/data/ab", "", false},         // shorter than the ".000" suffix
+		{"deep/dir/B.000", "B", true}, // a dir separator in the path is fine; the id is the base
+		{"/data/...000", "", false},   // id would be ".."  -> traversal
+		{"/data/..000", "", false},    // id would be "."
+		{"/data/.000", "", false},     // id would be empty
+		{"/data/ab", "", false},       // shorter than the ".000" suffix
 	}
 	for _, c := range cases {
 		got, ok := safeCellID(c.path)

--- a/s57/dataset/usageband.go
+++ b/s57/dataset/usageband.go
@@ -2,15 +2,14 @@ package dataset
 
 import (
 	"github.com/lukeroth/gdal"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
-// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
-// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads the
-// authoritative DSID_INTU value from the cell's DSID record. The DSID layer is
-// geometry-less and therefore excluded from File.Layers, so we open the datasource
-// and scan layers by index. Falls back to the navigational-purpose digit in the
-// cell name (3rd character, e.g. US"4"WA1JJ) and returns 0 when unknown.
-func UsageBand(file File) int {
+// dsidInfo reads the cell's DSID record once and returns the usage band
+// (DSID_INTU) and the compilation-scale denominator (DSPM_CSCL); each is 0 when
+// absent. The DSID layer is geometry-less and therefore excluded from
+// File.Layers, so we open the datasource and scan layers by index.
+func dsidInfo(file File) (intu int, cscl int) {
 	ds := gdal.OpenDataSource(file.Path, 0)
 	defer ds.Destroy()
 	for i := 0; i < ds.LayerCount(); i++ {
@@ -21,21 +20,40 @@ func UsageBand(file File) int {
 		layer.ResetReading()
 		feat := layer.NextFeature()
 		if feat != nil {
-			band := 0
 			if idx := feat.FieldIndex("DSID_INTU"); idx >= 0 && feat.IsFieldSet(idx) {
-				band = int(feat.FieldAsInteger64(idx))
+				intu = int(feat.FieldAsInteger64(idx))
+			}
+			if idx := feat.FieldIndex("DSPM_CSCL"); idx >= 0 && feat.IsFieldSet(idx) {
+				cscl = int(feat.FieldAsInteger64(idx))
 			}
 			feat.Destroy()
-			if band >= 1 && band <= 6 {
-				return band
-			}
 		}
 		break
 	}
-	if len(file.Id) >= 3 && file.Id[2] >= '1' && file.Id[2] <= '6' {
-		return int(file.Id[2] - '0')
+	return intu, cscl
+}
+
+// resolveBand maps a cell's DSID_INTU and id to a standard S-57 usage band
+// (1..6), falling back to the navigational-purpose digit in the cell name (3rd
+// character, e.g. US"4"WA1JJ) and returning 0 when neither yields 1..6 (e.g. an
+// Inland-ENC band such as 7).
+func resolveBand(intu int, id string) int {
+	if intu >= 1 && intu <= 6 {
+		return intu
+	}
+	if len(id) >= 3 && id[2] >= '1' && id[2] <= '6' {
+		return int(id[2] - '0')
 	}
 	return 0
+}
+
+// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
+// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads
+// the authoritative DSID_INTU value from the cell's DSID record, falls back to
+// the navigational-purpose digit in the cell name, and returns 0 when unknown.
+func UsageBand(file File) int {
+	intu, _ := dsidInfo(file)
+	return resolveBand(intu, file.Id)
 }
 
 // BandZoom maps a usage band to a default web-map zoom range. The values are a
@@ -58,4 +76,53 @@ func BandZoom(band int) (minZoom, maxZoom int) {
 	default:
 		return 9, 14
 	}
+}
+
+// ZoomRange is the web-map zoom range a cell is tiled to by default: from a
+// sensible coarse Min up to Max, the finest zoom matching the cell's native
+// detail. There is no artificial cap — a chart is tiled to the resolution it
+// actually contains, so nothing relies on the consuming client overzooming.
+// Users can still narrow this with -minzoom/-maxzoom.
+type ZoomRange struct {
+	Min, Max int
+}
+
+// CellZoomRange returns a cell's default zoom range from a single DSID read. The
+// minimum comes from the usage band (overview charts start coarse, harbour
+// charts start fine); for an inland/unknown band it is a fixed floor. The
+// maximum is the cell's native zoom — the finest level matching its compilation
+// scale (DSPM_CSCL) — and is never capped below the band default. So a 1:2000
+// inland chart tiles up to z19 and a 1:20000 approach chart up to z16.
+func CellZoomRange(file File) ZoomRange {
+	const inlandFloor = 12 // coarse floor for inland/large-scale cells (no usage band)
+	intu, cscl := dsidInfo(file)
+	band := resolveBand(intu, file.Id)
+
+	var minZ, maxZ int
+	switch {
+	case band >= 1 && band <= 6:
+		minZ, maxZ = BandZoom(band) // marine: usage-band min and max
+	case cscl > 0:
+		minZ, maxZ = inlandFloor, int(m.ZoomForScale(int32(cscl)))
+	default:
+		minZ, maxZ = BandZoom(0) // no band, no scale -> historical 9..14
+	}
+
+	// Extend the max to the cell's native compilation scale when that is finer,
+	// so a detailed chart isn't tiled below the resolution it actually contains.
+	if cscl > 0 {
+		if native := int(m.ZoomForScale(int32(cscl))); native > maxZ {
+			maxZ = native
+		}
+	}
+	if minZ > maxZ {
+		minZ = maxZ
+	}
+	return ZoomRange{Min: minZ, Max: maxZ}
+}
+
+// CellZoom returns a cell's default web-map zoom range; see CellZoomRange.
+func CellZoom(file File) (minZoom, maxZoom int) {
+	r := CellZoomRange(file)
+	return r.Min, r.Max
 }

--- a/s57/dataset/usageband_test.go
+++ b/s57/dataset/usageband_test.go
@@ -47,3 +47,94 @@ func TestUsageBandFromDSID(t *testing.T) {
 		t.Skip("US4WA1JJ not found in sample ENC")
 	}
 }
+
+// TestCellZoom verifies per-cell zoom derivation: a marine cell keeps the
+// usage-band mapping unchanged, while a large-scale Inland ENC (DSID_INTU=7,
+// 1:2000) is tiled to a higher, scale-derived range instead of the coarse 9–14
+// default that left it blank in Freeboard. The expected (12,16) is the capped
+// derivation: ZoomForScale(2000)=19 -> cap 16, min = 16-4 floored at 12.
+func TestCellZoom(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]struct {
+		band             int
+		minZoom, maxZoom int
+	}{
+		"US4WA1JJ": {4, 10, 14}, // marine Approach: BandZoom path, unchanged
+		"1R7WAD01": {0, 12, 19}, // inland 1:2000: band 7 -> 0 -> native scale z19 (no cap)
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			if got := UsageBand(f); got != w.band {
+				t.Errorf("UsageBand(%s) = %d, want %d", f.Id, got, w.band)
+			}
+			gotMin, gotMax := CellZoom(f)
+			if gotMin != w.minZoom || gotMax != w.maxZoom {
+				t.Errorf("CellZoom(%s) = (%d,%d), want (%d,%d)", f.Id, gotMin, gotMax, w.minZoom, w.maxZoom)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}
+
+// TestCellZoomRange verifies the default range runs up to each cell's native
+// compilation scale with no cap: the inland 1:2000 cell tiles to z19, while the
+// bundled marine cells stay at their band default (which already meets/exceeds
+// their native scale).
+func TestCellZoomRange(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]ZoomRange{
+		"1R7WAD01": {Min: 12, Max: 19}, // inland 1:2000 -> native z19 (no cap)
+		"US4WA1JJ": {Min: 10, Max: 14}, // marine 1:45000 -> band default already at native z14
+		"US4WI1DP": {Min: 10, Max: 14}, // marine 1:90000 -> native z13, kept at band max 14
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			got := CellZoomRange(f)
+			if got != w {
+				t.Errorf("CellZoomRange(%s) = %+v, want %+v", f.Id, got, w)
+			}
+			if got.Min > got.Max {
+				t.Errorf("CellZoomRange(%s): min %d > max %d", f.Id, got.Min, got.Max)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}

--- a/s57/features_test.go
+++ b/s57/features_test.go
@@ -307,3 +307,40 @@ func valuesForKey(layer *vectortile.Tile_Layer, key string) []string {
 	}
 	return out
 }
+
+// TestInlandCellRendersAtZoom is the end-to-end guard for the blank Inland-ENC
+// bug. It exercises the full pipeline for a large-scale (1:2000, DSID_INTU=7)
+// cell — nested-catalog discovery through tiling — and asserts it emits feature
+// geometry at the higher zoom CellZoom now selects. The depth contours it checks
+// carry SCAMIN ~15000, the detail that was missing when these cells were tiled
+// only to z14.
+func TestInlandCellRendersAtZoom(t *testing.T) {
+	if _, err := os.Stat(sampleENC); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", sampleENC, err)
+	}
+	datasets, err := dataset.GetS57Datasets(sampleENC)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	var cell *dataset.File
+	for di := range datasets {
+		for fi := range datasets[di].Files {
+			if datasets[di].Files[fi].Id == "1R7WAD01" {
+				cell = &datasets[di].Files[fi]
+			}
+		}
+	}
+	if cell == nil {
+		t.Skip("inland cell 1R7WAD01 not present in sample ENC")
+	}
+
+	const layerName = "DEPCNT" // depth contours: SCAMIN-gated, the missing detail
+	lon, lat, ok := firstFeatureCoord(cell, layerName)
+	if !ok {
+		t.Skipf("no %s feature in %s", layerName, cell.Id)
+	}
+	if l := findLayerInTiles(t, datasets, cell, lon, lat, layerName); l == nil {
+		t.Fatalf("inland cell %s produced no %s features at any zoom up to 16", cell.Id, layerName)
+	}
+}

--- a/s57/mercantile/mercantile.go
+++ b/s57/mercantile/mercantile.go
@@ -78,6 +78,8 @@ func Scale(tileid TileID) int32 {
 		return 70000
 	case 14:
 		return 35000
+	case 15:
+		return 24000
 	case 16:
 		return 15000
 	case 17:
@@ -97,6 +99,29 @@ func Scale(tileid TileID) int32 {
 	default:
 		return 0
 	}
+}
+
+// ZoomForScale returns the finest (highest) web-map zoom whose mapped scale
+// denominator (see Scale) is still >= the given chart compilation-scale
+// denominator. It is the inverse of Scale: a 1:2000 chart (scaleDenominator =
+// 2000) resolves to the zoom its detail is authored for. It is driven off the
+// same Scale table so the mapping lives in exactly one place.
+//
+// Scale denominators decrease as zoom increases, so we walk zoom upward and stop
+// at the first level whose Scale is <= the requested denominator. A non-positive
+// denominator (e.g. missing DSPM_CSCL) yields 0; a denominator finer than the
+// table's deepest entry clamps to that deepest zoom.
+func ZoomForScale(scaleDenominator int32) uint64 {
+	if scaleDenominator <= 0 {
+		return 0
+	}
+	const maxTableZoom = 23 // deepest zoom Scale defines
+	for z := uint64(0); z <= maxTableZoom; z++ {
+		if Scale(TileID{Z: z}) <= scaleDenominator {
+			return z
+		}
+	}
+	return maxTableZoom
 }
 
 // Returns the (x, y, z) tile.

--- a/s57/mercantile/mercantile.go
+++ b/s57/mercantile/mercantile.go
@@ -151,6 +151,9 @@ func Tilestr(tileid TileID) string {
 // From a tilestr representation back to a tileid
 func Strtile(tileid string) TileID {
 	vals := strings.Split(tileid, "/")
+	if len(vals) < 3 {
+		return TileID{}
+	}
 	x, _ := strconv.ParseInt(vals[0], 0, 64)
 	y, _ := strconv.ParseInt(vals[1], 0, 64)
 	z, _ := strconv.ParseInt(vals[2], 0, 64)
@@ -201,6 +204,9 @@ func TileFromString(val string) TileID {
 		vals = strings.Split(val, " ")
 	}
 
+	if len(vals) < 3 {
+		return TileID{}
+	}
 	x, _ := strconv.ParseInt(vals[0], 0, 64)
 	y, _ := strconv.ParseInt(vals[1], 0, 64)
 	z, _ := strconv.ParseInt(vals[2], 0, 64)

--- a/s57/mercantile/mercantile_test.go
+++ b/s57/mercantile/mercantile_test.go
@@ -1,0 +1,64 @@
+package mercantile
+
+import (
+	"math"
+	"testing"
+)
+
+// TestScaleNoZeroGapsMonotonic guards the scale table: every zoom z0..z23 must
+// map to a positive, strictly-decreasing denominator. This catches a missing
+// case (e.g. z15 previously fell through to the default 0, which broke the
+// SCAMIN/SCAMAX comparison in includeFeatureInTile at that zoom).
+func TestScaleNoZeroGapsMonotonic(t *testing.T) {
+	prev := int32(math.MaxInt32)
+	for z := uint64(0); z <= 23; z++ {
+		s := Scale(TileID{Z: z})
+		if s <= 0 {
+			t.Errorf("Scale(z=%d) = %d; want > 0 (no gaps z0..z23)", z, s)
+		}
+		if s >= prev {
+			t.Errorf("Scale not strictly decreasing at z=%d: %d >= %d", z, s, prev)
+		}
+		prev = s
+	}
+	if got := Scale(TileID{Z: 15}); got != 24000 {
+		t.Errorf("Scale(z=15) = %d; want 24000", got)
+	}
+}
+
+// TestZoomForScale locks the Scale inverse, including the clamps for a
+// missing/garbage compilation scale and out-of-table denominators.
+func TestZoomForScale(t *testing.T) {
+	cases := []struct {
+		scale int32
+		want  uint64
+	}{
+		{2000, 19},
+		{4000, 18},
+		{8000, 17},
+		{15000, 16},
+		{24000, 15},
+		{35000, 14},
+		{90000, 13},
+		{0, 0},         // missing DSPM_CSCL
+		{-5, 0},        // garbage
+		{1, 23},        // finer than the table -> deepest zoom
+		{600000000, 0}, // coarser than z0 -> 0
+	}
+	for _, c := range cases {
+		if got := ZoomForScale(c.scale); got != c.want {
+			t.Errorf("ZoomForScale(%d) = %d; want %d", c.scale, got, c.want)
+		}
+	}
+}
+
+// TestZoomForScaleRoundTrips ties Scale and ZoomForScale together: because the
+// table is gap-free and strictly decreasing, the inverse is exact at every table
+// point, so the two functions cannot drift apart.
+func TestZoomForScaleRoundTrips(t *testing.T) {
+	for z := uint64(0); z <= 23; z++ {
+		if got := ZoomForScale(Scale(TileID{Z: z})); got != z {
+			t.Errorf("ZoomForScale(Scale(z=%d)) = %d; want %d", z, got, z)
+		}
+	}
+}

--- a/s57/mercantile/parsers_test.go
+++ b/s57/mercantile/parsers_test.go
@@ -1,0 +1,34 @@
+package mercantile
+
+import "testing"
+
+// The tilestr parsers are fed strings from filenames/URLs, so malformed input
+// must not panic (it previously indexed vals[1]/vals[2] without a length check,
+// and TileFromString dereferenced a nil slice when no delimiter matched).
+
+func TestStrtileShortInputDoesNotPanic(t *testing.T) {
+	if got := Strtile("1/2"); got != (TileID{}) {
+		t.Errorf("Strtile(\"1/2\") = %+v, want zero TileID", got)
+	}
+	if got := Strtile(""); got != (TileID{}) {
+		t.Errorf("Strtile(\"\") = %+v, want zero TileID", got)
+	}
+}
+
+func TestStrtileValidRoundTrips(t *testing.T) {
+	if got := Strtile("3/5/7"); got != (TileID{X: 3, Y: 5, Z: 7}) {
+		t.Errorf("Strtile(\"3/5/7\") = %+v, want {3,5,7}", got)
+	}
+}
+
+func TestTileFromStringNoDelimiterDoesNotPanic(t *testing.T) {
+	if got := TileFromString("garbage"); got != (TileID{}) {
+		t.Errorf("TileFromString(\"garbage\") = %+v, want zero TileID", got)
+	}
+}
+
+func TestTileFromStringValid(t *testing.T) {
+	if got := TileFromString("3-5-7"); got != (TileID{X: 3, Y: 5, Z: 7}) {
+		t.Errorf("TileFromString(\"3-5-7\") = %+v, want {3,5,7}", got)
+	}
+}

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -359,6 +359,11 @@ func decodeListString(s string) string {
 
 func (s *s57Tiler) toMvtFeature(feature *gdal.Feature, tile m.TileID, tileBounds m.Extrema) *vectortile.Tile_Feature {
 	geom := feature.Geometry()
+	// A malformed record can carry a null geometry; bail before dereferencing it
+	// (getMvtFeatureType/toMvtGeometry would otherwise call into a nil handle).
+	if geom.IsNull() {
+		return nil
+	}
 	mvtFeature := vectortile.Tile_Feature{}
 	mvtFeature.Type = s.getMvtFeatureType(&geom)
 	if *mvtFeature.Type != vectortile.Tile_UNKNOWN {


### PR DESCRIPTION
## Why

ENC data can be third-party. A few spots assumed well-formed input and would crash, leak, or in one case write outside the output directory:

- **Catalog parsing** indexed `d.Fields[1].SubFields[5]` (and `[2]`, `[3]`) with no length check — a truncated or unexpected `CATALOG.031` record panics with index-out-of-range during discovery, taking the whole tool down.
- **The cell id** is the `.000` base name minus its extension and is later joined into the output path. A crafted name resolving to `..`, `.`, or empty would let the tile path escape `-out`.
- **`Strtile` / `TileFromString`** indexed `vals[1]`/`vals[2]` without checking length and dereferenced a nil slice when no delimiter matched — both panic on malformed tile strings.
- **Discovery leaked handles:** the per-cell `datasource.Destroy()` was `defer`red inside the catalog loop, so every cell in a catalog stayed open until the whole walk returned (FD exhaustion on a large catalog like full NOAA), and the `CATALOG.031` file handle was never closed.
- **A null geometry** on a malformed feature was dereferenced in `toMvtFeature`.

## What changed

- `catalogCellRef(rec)` (new) bounds-checks every field/subfield access and returns `ok=false` to skip a bad record instead of panicking. Behavior for valid catalogs is unchanged.
- `safeCellID(path)` (new) derives the id and rejects `.`/`..`/separators/empty.
- Discovery now also **skips cells the catalog references but that are missing/unreadable** (via `os.Stat`, since the binding can't report a failed `OpenDataSource`), **closes** the catalog file handle (`defer f.Close()`), and **releases each cell's datasource immediately** rather than deferring.
- `Strtile` / `TileFromString` return a zero `TileID` on short / delimiter-less input.
- `toMvtFeature` returns early on `geom.IsNull()`.

## Tests

- `s57/dataset/discovery_test.go` (new, hermetic): `TestCatalogCellRef` (valid row, non-BIN, non-`.000`, truncated record, too-few-fields) and `TestSafeCellID` (valid ids + the `..`/`.`/empty/short traversal cases). Written test-first (committed red — helpers undefined — then green).
- `s57/mercantile/parsers_test.go` (new, hermetic): `Strtile`/`TileFromString` no longer panic on short / delimiter-less input and still round-trip valid input. Written test-first (committed red — they panicked).

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` green ·
`go test -race ./s57/ ./s57/dataset/` clean.

## Notes / known gaps

- **Datasource/layer validity is only partially addressable here.** The GDAL binding (`wdantuma/gdal`) exposes `Geometry.IsNull()`/`Feature.IsNull()` but **no** `IsNull` for `DataSource` or `Layer` (the `cval` is unexported) and no error-returning OGR open. So a *present-but-corrupt* cell that opens to a nil handle, and a layer-name lookup that returns an invalid handle, still can't be guarded from this repo. The `os.Stat` pre-check covers the common missing-file case; a full fix would need an upstream `IsNull()` on those types (worth a small PR to the binding fork).