### PR TITLE
Fix: return write errors instead of crashing the whole run

### DIFF
--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 func main() {
@@ -181,6 +182,19 @@ func main() {
 	// can be very large, so surface the count before the (possibly long) tiling.
 	fmt.Printf("Generating %d tiles\n", grandTotal)
 
+	// Track write failures across all workers. A transient error (e.g. disk full,
+	// EPERM) no longer aborts the whole multi-hour run via log.Fatal; instead we
+	// keep going, surface the first error, count the rest, and exit non-zero at the
+	// end so a failed run is never mistaken for a complete one.
+	var failCount int64
+	var failOnce sync.Once
+	recordFailure := func(what string, err error) {
+		atomic.AddInt64(&failCount, 1)
+		failOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "\nerror: %s: %v\n", what, err)
+		})
+	}
+
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()
 	for _, wu := range work {
@@ -198,7 +212,9 @@ func main() {
 				workerTiler := s57.NewS57Tiler(datasets)
 				defer workerTiler.Close()
 				for tile := range jobs {
-					workerTiler.GenerateTile(*outputPath, wu.file, tile)
+					if err := workerTiler.GenerateTile(*outputPath, wu.file, tile); err != nil {
+						recordFailure(fmt.Sprintf("tile %s z%d %d/%d", wu.file.Id, tile.Z, tile.X, tile.Y), err)
+					}
 					prog.inc()
 				}
 			}()
@@ -208,9 +224,16 @@ func main() {
 		}
 		close(jobs)
 		wg.Wait()
-		tiler.GenerateMetaData(*outputPath, wu.dataset, wu.file, wu.minzoom, wu.maxzoom)
+		if err := tiler.GenerateMetaData(*outputPath, wu.dataset, wu.file, wu.minzoom, wu.maxzoom); err != nil {
+			recordFailure("metadata "+wu.file.Id, err)
+		}
 	}
 	prog.finish()
+
+	if n := atomic.LoadInt64(&failCount); n > 0 {
+		fmt.Fprintf(os.Stderr, "Completed with %d write failure(s); output is incomplete.\n", n)
+		os.Exit(1)
+	}
 }
 
 // workUnit is the tile set for a single (dataset, file, zoom), materialized during

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -40,6 +40,22 @@ func main() {
 		*workers = 1
 	}
 
+	// The scale table (mercantile.Scale) is defined for z0..z23; beyond it the
+	// SCAMIN/SCAMAX filtering degrades, so clamp explicit flags into range.
+	const maxSupportedZoom = 23
+	clampZoom := func(name string, zp *int) {
+		switch {
+		case *zp < 0:
+			fmt.Printf("Note: -%s %d is below 0; clamped to 0.\n", name, *zp)
+			*zp = 0
+		case *zp > maxSupportedZoom:
+			fmt.Printf("Note: -%s %d exceeds the supported maximum z%d; clamped.\n", name, *zp, maxSupportedZoom)
+			*zp = maxSupportedZoom
+		}
+	}
+	clampZoom("minzoom", minzoom)
+	clampZoom("maxzoom", maxzoom)
+
 	// Honor explicit -minzoom/-maxzoom; otherwise the zoom range is derived per cell
 	// from its S-57 usage band (overview→berthing) in the pre-pass below.
 	userSetZoom := false
@@ -116,11 +132,21 @@ func main() {
 	fmt.Println("Scanning…")
 	var work []workUnit
 	var grandTotal int64
+	var reports []zoomReport
 	for _, ds := range datasets {
 		for _, file := range ds.Files {
 			fminzoom, fmaxzoom := *minzoom, *maxzoom
-			if !userSetZoom && tile == nil && bounds == nil {
-				fminzoom, fmaxzoom = dataset.BandZoom(dataset.UsageBand(file))
+			if tile == nil {
+				zr := dataset.CellZoomRange(file)
+				if !userSetZoom && bounds == nil {
+					fminzoom, fmaxzoom = zr.Min, zr.Max
+				}
+				reports = append(reports, zoomReport{
+					convMin:  fminzoom,
+					convMax:  fmaxzoom,
+					availMin: zr.Min,
+					availMax: zr.Max,
+				})
 			}
 			for z := fminzoom; z <= fmaxzoom; z++ {
 				var tiles map[string]m.TileID
@@ -141,6 +167,19 @@ func main() {
 			}
 		}
 	}
+
+	if lines, hint := summarizeZooms(reports); len(lines) > 0 {
+		fmt.Println("Zoom levels:")
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+		if hint != "" {
+			fmt.Println(hint)
+		}
+	}
+	// Print the grand total up front: a native-zoom run over large-scale charts
+	// can be very large, so surface the count before the (possibly long) tiling.
+	fmt.Printf("Generating %d tiles\n", grandTotal)
 
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()

--- a/cmd/s57-tiler/zoomsummary.go
+++ b/cmd/s57-tiler/zoomsummary.go
@@ -1,0 +1,86 @@
+package main
+
+import "fmt"
+
+// zoomReport records, for one cell, the zoom range that will be generated
+// (conv*) and the range the cell's data supports (avail*, the native detail
+// ceiling from the compilation scale).
+type zoomReport struct {
+	convMin, convMax   int
+	availMin, availMax int
+}
+
+// isSubset reports whether the converting range omits zoom levels the data
+// supports — finer detail above (convMax<availMax) or coarser views below
+// (convMin>availMin).
+func (r zoomReport) isSubset() bool {
+	return r.convMin > r.availMin || r.convMax < r.availMax
+}
+
+// summarizeZooms groups the reports by identical (converting, available) range
+// and returns one summary line per group plus a hint. The hint is empty unless
+// at least one cell omits available zoom levels; when present it names only the
+// flag(s) (-minzoom/-maxzoom) that would widen the range, using the envelope
+// across all subset cells. Groups are emitted in first-seen order, so output is
+// deterministic for a given input.
+func summarizeZooms(reports []zoomReport) (lines []string, hint string) {
+	if len(reports) == 0 {
+		return nil, ""
+	}
+
+	type group struct {
+		rep   zoomReport
+		count int
+	}
+	var order []string
+	groups := map[string]*group{}
+	for _, r := range reports {
+		key := fmt.Sprintf("%d-%d/%d-%d", r.convMin, r.convMax, r.availMin, r.availMax)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{rep: r}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.count++
+	}
+	for _, key := range order {
+		g := groups[key]
+		r := g.rep
+		line := fmt.Sprintf("  %d chart(s): converting z%d-z%d", g.count, r.convMin, r.convMax)
+		if r.isSubset() {
+			line += fmt.Sprintf("  (data available z%d-z%d)", r.availMin, r.availMax)
+		}
+		lines = append(lines, line)
+	}
+
+	minSubset, maxSubset := false, false
+	hintMin := int(^uint(0) >> 1)
+	hintMax := -1
+	for _, r := range reports {
+		if r.convMax < r.availMax {
+			maxSubset = true
+			if r.availMax > hintMax {
+				hintMax = r.availMax
+			}
+		}
+		if r.convMin > r.availMin {
+			minSubset = true
+			if r.availMin < hintMin {
+				hintMin = r.availMin
+			}
+		}
+	}
+	switch {
+	case minSubset && maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits detail some charts contain; "+
+			"pass -minzoom %d -maxzoom %d for their full native range (more tiles).", hintMin, hintMax)
+	case maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits finer detail some charts contain; "+
+			"pass -maxzoom %d to tile their full native range (more tiles).", hintMax)
+	case minSubset:
+		hint = fmt.Sprintf("The selected zoom omits coarser levels some charts cover; "+
+			"pass -minzoom %d to include them.", hintMin)
+	}
+	return lines, hint
+}

--- a/cmd/s57-tiler/zoomsummary_test.go
+++ b/cmd/s57-tiler/zoomsummary_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSummarizeZoomsSubsetHint: a group whose converting max is below its
+// available max is flagged as a subset, shows the available range, and triggers
+// a -maxzoom hint naming the envelope max. Identical ranges collapse to one line.
+func TestSummarizeZoomsSubsetHint(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // subset (max)
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // same group
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14}, // full range
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 grouped lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "2 chart(s)") || !strings.Contains(lines[0], "z12-z16") {
+		t.Errorf("group line 0 = %q, want 2 charts converting z12-z16", lines[0])
+	}
+	if !strings.Contains(lines[0], "available z12-z19") {
+		t.Errorf("subset line should show the available range, got %q", lines[0])
+	}
+	if strings.Contains(lines[1], "available") {
+		t.Errorf("full-range line should not show an available range, got %q", lines[1])
+	}
+	if hint == "" {
+		t.Fatal("expected a hint when a group is a subset")
+	}
+	if !strings.Contains(hint, "-maxzoom 19") {
+		t.Errorf("hint should suggest -maxzoom 19, got %q", hint)
+	}
+	if strings.Contains(hint, "-minzoom") {
+		t.Errorf("hint should not mention -minzoom when only the max is a subset, got %q", hint)
+	}
+}
+
+// TestSummarizeZoomsNoHintWhenFull: when every cell covers its full available
+// range, no hint is produced and no "available" suffix is shown.
+func TestSummarizeZoomsNoHintWhenFull(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14},
+		{convMin: 13, convMax: 17, availMin: 13, availMax: 17},
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if hint != "" {
+		t.Errorf("expected no hint when nothing is a subset, got %q", hint)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	for _, l := range lines {
+		if strings.Contains(l, "available") {
+			t.Errorf("full-range line should omit available, got %q", l)
+		}
+	}
+}
+
+// TestSummarizeZoomsMinSubset: a narrowed low end (override) yields a -minzoom hint.
+func TestSummarizeZoomsMinSubset(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 14, convMax: 16, availMin: 12, availMax: 16}, // subset (min only)
+	}
+	_, hint := summarizeZooms(reports)
+	if !strings.Contains(hint, "-minzoom 12") {
+		t.Errorf("hint should suggest -minzoom 12, got %q", hint)
+	}
+	if strings.Contains(hint, "-maxzoom") {
+		t.Errorf("hint should not mention -maxzoom when only the min is a subset, got %q", hint)
+	}
+}
+
+func TestSummarizeZoomsEmpty(t *testing.T) {
+	lines, hint := summarizeZooms(nil)
+	if lines != nil || hint != "" {
+		t.Errorf("empty input should give empty output, got lines=%v hint=%q", lines, hint)
+	}
+}

--- a/s57/dataset/usageband.go
+++ b/s57/dataset/usageband.go
@@ -2,15 +2,14 @@ package dataset
 
 import (
 	"github.com/lukeroth/gdal"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
-// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
-// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads the
-// authoritative DSID_INTU value from the cell's DSID record. The DSID layer is
-// geometry-less and therefore excluded from File.Layers, so we open the datasource
-// and scan layers by index. Falls back to the navigational-purpose digit in the
-// cell name (3rd character, e.g. US"4"WA1JJ) and returns 0 when unknown.
-func UsageBand(file File) int {
+// dsidInfo reads the cell's DSID record once and returns the usage band
+// (DSID_INTU) and the compilation-scale denominator (DSPM_CSCL); each is 0 when
+// absent. The DSID layer is geometry-less and therefore excluded from
+// File.Layers, so we open the datasource and scan layers by index.
+func dsidInfo(file File) (intu int, cscl int) {
 	ds := gdal.OpenDataSource(file.Path, 0)
 	defer ds.Destroy()
 	for i := 0; i < ds.LayerCount(); i++ {
@@ -21,21 +20,40 @@ func UsageBand(file File) int {
 		layer.ResetReading()
 		feat := layer.NextFeature()
 		if feat != nil {
-			band := 0
 			if idx := feat.FieldIndex("DSID_INTU"); idx >= 0 && feat.IsFieldSet(idx) {
-				band = int(feat.FieldAsInteger64(idx))
+				intu = int(feat.FieldAsInteger64(idx))
+			}
+			if idx := feat.FieldIndex("DSPM_CSCL"); idx >= 0 && feat.IsFieldSet(idx) {
+				cscl = int(feat.FieldAsInteger64(idx))
 			}
 			feat.Destroy()
-			if band >= 1 && band <= 6 {
-				return band
-			}
 		}
 		break
 	}
-	if len(file.Id) >= 3 && file.Id[2] >= '1' && file.Id[2] <= '6' {
-		return int(file.Id[2] - '0')
+	return intu, cscl
+}
+
+// resolveBand maps a cell's DSID_INTU and id to a standard S-57 usage band
+// (1..6), falling back to the navigational-purpose digit in the cell name (3rd
+// character, e.g. US"4"WA1JJ) and returning 0 when neither yields 1..6 (e.g. an
+// Inland-ENC band such as 7).
+func resolveBand(intu int, id string) int {
+	if intu >= 1 && intu <= 6 {
+		return intu
+	}
+	if len(id) >= 3 && id[2] >= '1' && id[2] <= '6' {
+		return int(id[2] - '0')
 	}
 	return 0
+}
+
+// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
+// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads
+// the authoritative DSID_INTU value from the cell's DSID record, falls back to
+// the navigational-purpose digit in the cell name, and returns 0 when unknown.
+func UsageBand(file File) int {
+	intu, _ := dsidInfo(file)
+	return resolveBand(intu, file.Id)
 }
 
 // BandZoom maps a usage band to a default web-map zoom range. The values are a
@@ -58,4 +76,53 @@ func BandZoom(band int) (minZoom, maxZoom int) {
 	default:
 		return 9, 14
 	}
+}
+
+// ZoomRange is the web-map zoom range a cell is tiled to by default: from a
+// sensible coarse Min up to Max, the finest zoom matching the cell's native
+// detail. There is no artificial cap — a chart is tiled to the resolution it
+// actually contains, so nothing relies on the consuming client overzooming.
+// Users can still narrow this with -minzoom/-maxzoom.
+type ZoomRange struct {
+	Min, Max int
+}
+
+// CellZoomRange returns a cell's default zoom range from a single DSID read. The
+// minimum comes from the usage band (overview charts start coarse, harbour
+// charts start fine); for an inland/unknown band it is a fixed floor. The
+// maximum is the cell's native zoom — the finest level matching its compilation
+// scale (DSPM_CSCL) — and is never capped below the band default. So a 1:2000
+// inland chart tiles up to z19 and a 1:20000 approach chart up to z16.
+func CellZoomRange(file File) ZoomRange {
+	const inlandFloor = 12 // coarse floor for inland/large-scale cells (no usage band)
+	intu, cscl := dsidInfo(file)
+	band := resolveBand(intu, file.Id)
+
+	var minZ, maxZ int
+	switch {
+	case band >= 1 && band <= 6:
+		minZ, maxZ = BandZoom(band) // marine: usage-band min and max
+	case cscl > 0:
+		minZ, maxZ = inlandFloor, int(m.ZoomForScale(int32(cscl)))
+	default:
+		minZ, maxZ = BandZoom(0) // no band, no scale -> historical 9..14
+	}
+
+	// Extend the max to the cell's native compilation scale when that is finer,
+	// so a detailed chart isn't tiled below the resolution it actually contains.
+	if cscl > 0 {
+		if native := int(m.ZoomForScale(int32(cscl))); native > maxZ {
+			maxZ = native
+		}
+	}
+	if minZ > maxZ {
+		minZ = maxZ
+	}
+	return ZoomRange{Min: minZ, Max: maxZ}
+}
+
+// CellZoom returns a cell's default web-map zoom range; see CellZoomRange.
+func CellZoom(file File) (minZoom, maxZoom int) {
+	r := CellZoomRange(file)
+	return r.Min, r.Max
 }

--- a/s57/dataset/usageband_test.go
+++ b/s57/dataset/usageband_test.go
@@ -47,3 +47,94 @@ func TestUsageBandFromDSID(t *testing.T) {
 		t.Skip("US4WA1JJ not found in sample ENC")
 	}
 }
+
+// TestCellZoom verifies per-cell zoom derivation: a marine cell keeps the
+// usage-band mapping unchanged, while a large-scale Inland ENC (DSID_INTU=7,
+// 1:2000) is tiled to a higher, scale-derived range instead of the coarse 9–14
+// default that left it blank in Freeboard. The expected (12,16) is the capped
+// derivation: ZoomForScale(2000)=19 -> cap 16, min = 16-4 floored at 12.
+func TestCellZoom(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]struct {
+		band             int
+		minZoom, maxZoom int
+	}{
+		"US4WA1JJ": {4, 10, 14}, // marine Approach: BandZoom path, unchanged
+		"1R7WAD01": {0, 12, 19}, // inland 1:2000: band 7 -> 0 -> native scale z19 (no cap)
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			if got := UsageBand(f); got != w.band {
+				t.Errorf("UsageBand(%s) = %d, want %d", f.Id, got, w.band)
+			}
+			gotMin, gotMax := CellZoom(f)
+			if gotMin != w.minZoom || gotMax != w.maxZoom {
+				t.Errorf("CellZoom(%s) = (%d,%d), want (%d,%d)", f.Id, gotMin, gotMax, w.minZoom, w.maxZoom)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}
+
+// TestCellZoomRange verifies the default range runs up to each cell's native
+// compilation scale with no cap: the inland 1:2000 cell tiles to z19, while the
+// bundled marine cells stay at their band default (which already meets/exceeds
+// their native scale).
+func TestCellZoomRange(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]ZoomRange{
+		"1R7WAD01": {Min: 12, Max: 19}, // inland 1:2000 -> native z19 (no cap)
+		"US4WA1JJ": {Min: 10, Max: 14}, // marine 1:45000 -> band default already at native z14
+		"US4WI1DP": {Min: 10, Max: 14}, // marine 1:90000 -> native z13, kept at band max 14
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			got := CellZoomRange(f)
+			if got != w {
+				t.Errorf("CellZoomRange(%s) = %+v, want %+v", f.Id, got, w)
+			}
+			if got.Min > got.Max {
+				t.Errorf("CellZoomRange(%s): min %d > max %d", f.Id, got.Min, got.Max)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}

--- a/s57/features_test.go
+++ b/s57/features_test.go
@@ -307,3 +307,40 @@ func valuesForKey(layer *vectortile.Tile_Layer, key string) []string {
 	}
 	return out
 }
+
+// TestInlandCellRendersAtZoom is the end-to-end guard for the blank Inland-ENC
+// bug. It exercises the full pipeline for a large-scale (1:2000, DSID_INTU=7)
+// cell — nested-catalog discovery through tiling — and asserts it emits feature
+// geometry at the higher zoom CellZoom now selects. The depth contours it checks
+// carry SCAMIN ~15000, the detail that was missing when these cells were tiled
+// only to z14.
+func TestInlandCellRendersAtZoom(t *testing.T) {
+	if _, err := os.Stat(sampleENC); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", sampleENC, err)
+	}
+	datasets, err := dataset.GetS57Datasets(sampleENC)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	var cell *dataset.File
+	for di := range datasets {
+		for fi := range datasets[di].Files {
+			if datasets[di].Files[fi].Id == "1R7WAD01" {
+				cell = &datasets[di].Files[fi]
+			}
+		}
+	}
+	if cell == nil {
+		t.Skip("inland cell 1R7WAD01 not present in sample ENC")
+	}
+
+	const layerName = "DEPCNT" // depth contours: SCAMIN-gated, the missing detail
+	lon, lat, ok := firstFeatureCoord(cell, layerName)
+	if !ok {
+		t.Skipf("no %s feature in %s", layerName, cell.Id)
+	}
+	if l := findLayerInTiles(t, datasets, cell, lon, lat, layerName); l == nil {
+		t.Fatalf("inland cell %s produced no %s features at any zoom up to 16", cell.Id, layerName)
+	}
+}

--- a/s57/mercantile/mercantile.go
+++ b/s57/mercantile/mercantile.go
@@ -78,6 +78,8 @@ func Scale(tileid TileID) int32 {
 		return 70000
 	case 14:
 		return 35000
+	case 15:
+		return 24000
 	case 16:
 		return 15000
 	case 17:
@@ -97,6 +99,29 @@ func Scale(tileid TileID) int32 {
 	default:
 		return 0
 	}
+}
+
+// ZoomForScale returns the finest (highest) web-map zoom whose mapped scale
+// denominator (see Scale) is still >= the given chart compilation-scale
+// denominator. It is the inverse of Scale: a 1:2000 chart (scaleDenominator =
+// 2000) resolves to the zoom its detail is authored for. It is driven off the
+// same Scale table so the mapping lives in exactly one place.
+//
+// Scale denominators decrease as zoom increases, so we walk zoom upward and stop
+// at the first level whose Scale is <= the requested denominator. A non-positive
+// denominator (e.g. missing DSPM_CSCL) yields 0; a denominator finer than the
+// table's deepest entry clamps to that deepest zoom.
+func ZoomForScale(scaleDenominator int32) uint64 {
+	if scaleDenominator <= 0 {
+		return 0
+	}
+	const maxTableZoom = 23 // deepest zoom Scale defines
+	for z := uint64(0); z <= maxTableZoom; z++ {
+		if Scale(TileID{Z: z}) <= scaleDenominator {
+			return z
+		}
+	}
+	return maxTableZoom
 }
 
 // Returns the (x, y, z) tile.

--- a/s57/mercantile/mercantile_test.go
+++ b/s57/mercantile/mercantile_test.go
@@ -1,0 +1,64 @@
+package mercantile
+
+import (
+	"math"
+	"testing"
+)
+
+// TestScaleNoZeroGapsMonotonic guards the scale table: every zoom z0..z23 must
+// map to a positive, strictly-decreasing denominator. This catches a missing
+// case (e.g. z15 previously fell through to the default 0, which broke the
+// SCAMIN/SCAMAX comparison in includeFeatureInTile at that zoom).
+func TestScaleNoZeroGapsMonotonic(t *testing.T) {
+	prev := int32(math.MaxInt32)
+	for z := uint64(0); z <= 23; z++ {
+		s := Scale(TileID{Z: z})
+		if s <= 0 {
+			t.Errorf("Scale(z=%d) = %d; want > 0 (no gaps z0..z23)", z, s)
+		}
+		if s >= prev {
+			t.Errorf("Scale not strictly decreasing at z=%d: %d >= %d", z, s, prev)
+		}
+		prev = s
+	}
+	if got := Scale(TileID{Z: 15}); got != 24000 {
+		t.Errorf("Scale(z=15) = %d; want 24000", got)
+	}
+}
+
+// TestZoomForScale locks the Scale inverse, including the clamps for a
+// missing/garbage compilation scale and out-of-table denominators.
+func TestZoomForScale(t *testing.T) {
+	cases := []struct {
+		scale int32
+		want  uint64
+	}{
+		{2000, 19},
+		{4000, 18},
+		{8000, 17},
+		{15000, 16},
+		{24000, 15},
+		{35000, 14},
+		{90000, 13},
+		{0, 0},         // missing DSPM_CSCL
+		{-5, 0},        // garbage
+		{1, 23},        // finer than the table -> deepest zoom
+		{600000000, 0}, // coarser than z0 -> 0
+	}
+	for _, c := range cases {
+		if got := ZoomForScale(c.scale); got != c.want {
+			t.Errorf("ZoomForScale(%d) = %d; want %d", c.scale, got, c.want)
+		}
+	}
+}
+
+// TestZoomForScaleRoundTrips ties Scale and ZoomForScale together: because the
+// table is gap-free and strictly decreasing, the inverse is exact at every table
+// point, so the two functions cannot drift apart.
+func TestZoomForScaleRoundTrips(t *testing.T) {
+	for z := uint64(0); z <= 23; z++ {
+		if got := ZoomForScale(Scale(TileID{Z: z})); got != z {
+			t.Errorf("ZoomForScale(Scale(z=%d)) = %d; want %d", z, got, z)
+		}
+	}
+}

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -6,7 +6,6 @@ package s57
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -522,7 +521,7 @@ func getBounds(file dataset.File) []float32 {
 	return bounds
 }
 
-func (s *s57Tiler) GenerateMetaData(outPath string, dataset dataset.Dataset, file dataset.File, minZoom int, maxZoom int) {
+func (s *s57Tiler) GenerateMetaData(outPath string, dataset dataset.Dataset, file dataset.File, minZoom int, maxZoom int) error {
 	path := filepath.Join(outPath, file.Id, "metadata.json")
 	bounds := getBounds(file)
 	// Fall back to the cell's catalog long-name when the dataset has no description,
@@ -533,17 +532,22 @@ func (s *s57Tiler) GenerateMetaData(outPath string, dataset dataset.Dataset, fil
 	}
 	metaData := charts.ChartMetaData{Id: file.Id, Name: file.Id, Description: description, Created: time.Now().UTC(), Type: "S-57", Format: "pbf", MinZoom: minZoom, MaxZoom: maxZoom, Bounds: bounds}
 
-	out, _ := json.Marshal(metaData)
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		os.MkdirAll(filepath.Dir(path), 0700) // Create your file
-	}
-	err := os.WriteFile(path, out, 0644)
+	out, err := json.Marshal(metaData)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("marshal metadata for %s: %w", file.Id, err)
 	}
+	// MkdirAll is a no-op when the directory already exists, so call it
+	// unconditionally rather than guarding with a Stat.
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create directory for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
 }
 
-func (s *s57Tiler) GenerateTile(outPath string, file dataset.File, tile m.TileID) {
+func (s *s57Tiler) GenerateTile(outPath string, file dataset.File, tile m.TileID) error {
 	mvtTile := vectortile.Tile{}
 
 	//allowedLayers := []string{"BOYLAT", "BOYCAR", "BOYINB", "BOYISD", "BOYSAW", "BOYSPP", "BCNLAT", "BCNCAR", "BCNISN", "BCNSAW", "BCNSPP", "LIGHTS", "DEPARE", "SEAARE", "COALNE", "RESARE", "UNSARE", "LNDARE", "BUAARE", "NAVLNE", "RECTRC", "CANALS"}
@@ -606,15 +610,24 @@ func (s *s57Tiler) GenerateTile(outPath string, file dataset.File, tile m.TileID
 
 	path := filepath.Join(outPath, file.Id, strconv.Itoa(int(tile.Z)), strconv.Itoa(int(tile.X)), strconv.Itoa(int(tile.Y))) + ".pbf"
 	if len(mvtTile.Layers) > 0 {
-		out, _ := proto.Marshal(&mvtTile)
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			os.MkdirAll(filepath.Dir(path), 0700) // Create your file
-		}
-		err := os.WriteFile(path, out, 0644)
+		out, err := proto.Marshal(&mvtTile)
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("marshal tile %s: %w", path, err)
+		}
+		// MkdirAll is a no-op when the directory already exists, so call it
+		// unconditionally rather than guarding with a Stat.
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return fmt.Errorf("create directory for %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, out, 0644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
 		}
 	} else {
-		os.Remove(path)
+		// Best-effort cleanup of a now-empty tile; a missing file is fine, any
+		// other failure is surfaced so a stale invalid tile can't linger silently.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove empty tile %s: %w", path, err)
+		}
 	}
+	return nil
 }

--- a/s57/writepath_test.go
+++ b/s57/writepath_test.go
@@ -1,0 +1,112 @@
+package s57
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+	"github.com/wdantuma/signalk-server-go/resources/charts"
+)
+
+// TestGenerateMetaDataWritesValidMetadata is hermetic (no GDAL fixture): it drives
+// GenerateMetaData through the happy path and asserts a parseable metadata.json is
+// produced for the cell.
+func TestGenerateMetaDataWritesValidMetadata(t *testing.T) {
+	tiler := NewS57Tiler(nil)
+	defer tiler.Close()
+	out := t.TempDir()
+	file := dataset.File{Id: "TESTCELL"}
+	ds := dataset.Dataset{Description: "Test Chart"}
+
+	if err := tiler.GenerateMetaData(out, ds, file, 9, 14); err != nil {
+		t.Fatalf("GenerateMetaData: unexpected error: %v", err)
+	}
+	path := filepath.Join(out, "TESTCELL", "metadata.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("metadata not written: %v", err)
+	}
+	var md charts.ChartMetaData
+	if err := json.Unmarshal(b, &md); err != nil {
+		t.Fatalf("metadata.json is not valid JSON: %v", err)
+	}
+	if md.Id != "TESTCELL" {
+		t.Errorf("metadata Id = %q, want TESTCELL", md.Id)
+	}
+}
+
+// TestGenerateMetaDataReturnsErrorOnUnwritablePath asserts the write path surfaces
+// an error to the caller instead of calling log.Fatal (which would os.Exit the
+// whole worker pool mid-run). Pointing -out at a regular file makes MkdirAll fail
+// with ENOTDIR even when the test runs as root (CI runs in a root container), so
+// the check is portable.
+func TestGenerateMetaDataReturnsErrorOnUnwritablePath(t *testing.T) {
+	tiler := NewS57Tiler(nil)
+	defer tiler.Close()
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	file := dataset.File{Id: "TESTCELL"}
+	if err := tiler.GenerateMetaData(blocker, dataset.Dataset{}, file, 9, 14); err == nil {
+		t.Fatal("GenerateMetaData: expected an error writing under a regular file, got nil")
+	}
+}
+
+// TestGenerateTileReturnsErrorOnUnwritablePath drives the tile write path
+// (fixture-gated): a dense tile that really has features must surface a write error
+// rather than crash the worker. Skips when the bundled ENC is absent.
+func TestGenerateTileReturnsErrorOnUnwritablePath(t *testing.T) {
+	if _, err := os.Stat(sampleENC + "/CATALOG.031"); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", sampleENC, err)
+	}
+	datasets, err := dataset.GetS57Datasets(sampleENC)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+	var file *dataset.File
+	for di := range datasets {
+		for fi := range datasets[di].Files {
+			if datasets[di].Files[fi].Id == "US4WA1JJ" {
+				file = &datasets[di].Files[fi]
+			}
+		}
+	}
+	if file == nil {
+		t.Skip("US4WA1JJ not found in sample ENC")
+	}
+	mcovr, ok := file.Layers["M_COVR"]
+	if !ok {
+		t.Skip("fixture has no M_COVR layer")
+	}
+	lon := (mcovr.Bounds.MinX() + mcovr.Bounds.MaxX()) / 2
+	lat := (mcovr.Bounds.MinY() + mcovr.Bounds.MaxY()) / 2
+	tile := m.Tile(lon, lat, 14)
+
+	tiler := NewS57Tiler(datasets)
+	defer tiler.Close()
+
+	// Confirm the chosen tile is non-empty, so the test exercises the write path
+	// (an empty tile would take the os.Remove branch and never write).
+	good := t.TempDir()
+	if err := tiler.GenerateTile(good, *file, tile); err != nil {
+		t.Fatalf("GenerateTile to a writable dir failed: %v", err)
+	}
+	pbf := filepath.Join(good, file.Id, strconv.Itoa(int(tile.Z)),
+		strconv.Itoa(int(tile.X)), strconv.Itoa(int(tile.Y))+".pbf")
+	if _, err := os.Stat(pbf); err != nil {
+		t.Skipf("chosen tile z%d produced no features; can't exercise the write path", tile.Z)
+	}
+
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := tiler.GenerateTile(blocker, *file, tile); err == nil {
+		t.Fatal("GenerateTile: expected a write error under a regular file, got nil")
+	}
+}


### PR DESCRIPTION
## Why

When the tiler hit a write error it called `log.Fatal` — and those calls run inside worker goroutines. So a single transient failure late in a run (disk full, a permissions hiccup, EPERM) would `os.Exit(1)` the whole process with no cleanup, potentially throwing away hours of progress on a large native-zoom run (the Waddenzee set is ~3.7M tiles).

Two errors were also ignored entirely: the `json.Marshal` / `proto.Marshal` return values were discarded, so a marshal failure would write a nil/partial `metadata.json` or `.pbf` and carry on — silently corrupting the output. And the worker counted every tile as done regardless of success, so a broken run still printed a success summary.

## What changed

- `GenerateTile` and `GenerateMetaData` now return an `error` instead of calling `log.Fatal`.
- `Marshal`, `MkdirAll`, and `WriteFile` errors are all checked and wrapped with context (which tile/file failed).
- The empty-tile cleanup (`os.Remove`) now surfaces a real failure but still treats "already gone" as success.
- The redundant `Stat`-before-`MkdirAll` was removed — `MkdirAll` already no-ops when the directory exists.
- The CLI worker loop records failures across all workers, prints the first one, and exits non-zero at the end with a count — `Completed with N write failure(s); output is incomplete.` A failed run is no longer mistaken for a complete one.

## Tests

`s57/writepath_test.go` (new), written test-first (committed red, then made green):

- `TestGenerateMetaDataWritesValidMetadata` — hermetic happy path: `metadata.json` is written, parses, and carries the right cell id.
- `TestGenerateMetaDataReturnsErrorOnUnwritablePath` — hermetic: pointing `-out` at a regular file makes the write fail; asserts an error is **returned** (not a process exit). Using a file-as-parent makes `MkdirAll` fail with `ENOTDIR` even under root, which is how CI runs.
- `TestGenerateTileReturnsErrorOnUnwritablePath` — fixture-gated: generates a real dense tile to confirm it has features, then asserts the tile write path returns an error under an unwritable `-out`.

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` green ·
`go test -race ./s57/ ./cmd/...` clean.

## Notes

- The non-zero-exit / summary wiring lives in `main()` and isn't unit-tested directly (main is awkward to test); it's covered by the returned-error unit tests plus the build. A CLI-arg test harness lands in a later branch (`feat/operator-safety`).