### PR TITLE
Fix: grid clamp, int32 overflow, getBounds I/O, and SRS/transform leak

### DIFF
--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -40,6 +40,22 @@ func main() {
 		*workers = 1
 	}
 
+	// The scale table (mercantile.Scale) is defined for z0..z23; beyond it the
+	// SCAMIN/SCAMAX filtering degrades, so clamp explicit flags into range.
+	const maxSupportedZoom = 23
+	clampZoom := func(name string, zp *int) {
+		switch {
+		case *zp < 0:
+			fmt.Printf("Note: -%s %d is below 0; clamped to 0.\n", name, *zp)
+			*zp = 0
+		case *zp > maxSupportedZoom:
+			fmt.Printf("Note: -%s %d exceeds the supported maximum z%d; clamped.\n", name, *zp, maxSupportedZoom)
+			*zp = maxSupportedZoom
+		}
+	}
+	clampZoom("minzoom", minzoom)
+	clampZoom("maxzoom", maxzoom)
+
 	// Honor explicit -minzoom/-maxzoom; otherwise the zoom range is derived per cell
 	// from its S-57 usage band (overview→berthing) in the pre-pass below.
 	userSetZoom := false
@@ -116,11 +132,21 @@ func main() {
 	fmt.Println("Scanning…")
 	var work []workUnit
 	var grandTotal int64
+	var reports []zoomReport
 	for _, ds := range datasets {
 		for _, file := range ds.Files {
 			fminzoom, fmaxzoom := *minzoom, *maxzoom
-			if !userSetZoom && tile == nil && bounds == nil {
-				fminzoom, fmaxzoom = dataset.BandZoom(dataset.UsageBand(file))
+			if tile == nil {
+				zr := dataset.CellZoomRange(file)
+				if !userSetZoom && bounds == nil {
+					fminzoom, fmaxzoom = zr.Min, zr.Max
+				}
+				reports = append(reports, zoomReport{
+					convMin:  fminzoom,
+					convMax:  fmaxzoom,
+					availMin: zr.Min,
+					availMax: zr.Max,
+				})
 			}
 			for z := fminzoom; z <= fmaxzoom; z++ {
 				var tiles map[string]m.TileID
@@ -141,6 +167,19 @@ func main() {
 			}
 		}
 	}
+
+	if lines, hint := summarizeZooms(reports); len(lines) > 0 {
+		fmt.Println("Zoom levels:")
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+		if hint != "" {
+			fmt.Println(hint)
+		}
+	}
+	// Print the grand total up front: a native-zoom run over large-scale charts
+	// can be very large, so surface the count before the (possibly long) tiling.
+	fmt.Printf("Generating %d tiles\n", grandTotal)
 
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()

--- a/cmd/s57-tiler/zoomsummary.go
+++ b/cmd/s57-tiler/zoomsummary.go
@@ -1,0 +1,86 @@
+package main
+
+import "fmt"
+
+// zoomReport records, for one cell, the zoom range that will be generated
+// (conv*) and the range the cell's data supports (avail*, the native detail
+// ceiling from the compilation scale).
+type zoomReport struct {
+	convMin, convMax   int
+	availMin, availMax int
+}
+
+// isSubset reports whether the converting range omits zoom levels the data
+// supports — finer detail above (convMax<availMax) or coarser views below
+// (convMin>availMin).
+func (r zoomReport) isSubset() bool {
+	return r.convMin > r.availMin || r.convMax < r.availMax
+}
+
+// summarizeZooms groups the reports by identical (converting, available) range
+// and returns one summary line per group plus a hint. The hint is empty unless
+// at least one cell omits available zoom levels; when present it names only the
+// flag(s) (-minzoom/-maxzoom) that would widen the range, using the envelope
+// across all subset cells. Groups are emitted in first-seen order, so output is
+// deterministic for a given input.
+func summarizeZooms(reports []zoomReport) (lines []string, hint string) {
+	if len(reports) == 0 {
+		return nil, ""
+	}
+
+	type group struct {
+		rep   zoomReport
+		count int
+	}
+	var order []string
+	groups := map[string]*group{}
+	for _, r := range reports {
+		key := fmt.Sprintf("%d-%d/%d-%d", r.convMin, r.convMax, r.availMin, r.availMax)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{rep: r}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.count++
+	}
+	for _, key := range order {
+		g := groups[key]
+		r := g.rep
+		line := fmt.Sprintf("  %d chart(s): converting z%d-z%d", g.count, r.convMin, r.convMax)
+		if r.isSubset() {
+			line += fmt.Sprintf("  (data available z%d-z%d)", r.availMin, r.availMax)
+		}
+		lines = append(lines, line)
+	}
+
+	minSubset, maxSubset := false, false
+	hintMin := int(^uint(0) >> 1)
+	hintMax := -1
+	for _, r := range reports {
+		if r.convMax < r.availMax {
+			maxSubset = true
+			if r.availMax > hintMax {
+				hintMax = r.availMax
+			}
+		}
+		if r.convMin > r.availMin {
+			minSubset = true
+			if r.availMin < hintMin {
+				hintMin = r.availMin
+			}
+		}
+	}
+	switch {
+	case minSubset && maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits detail some charts contain; "+
+			"pass -minzoom %d -maxzoom %d for their full native range (more tiles).", hintMin, hintMax)
+	case maxSubset:
+		hint = fmt.Sprintf("The selected zoom omits finer detail some charts contain; "+
+			"pass -maxzoom %d to tile their full native range (more tiles).", hintMax)
+	case minSubset:
+		hint = fmt.Sprintf("The selected zoom omits coarser levels some charts cover; "+
+			"pass -minzoom %d to include them.", hintMin)
+	}
+	return lines, hint
+}

--- a/cmd/s57-tiler/zoomsummary_test.go
+++ b/cmd/s57-tiler/zoomsummary_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSummarizeZoomsSubsetHint: a group whose converting max is below its
+// available max is flagged as a subset, shows the available range, and triggers
+// a -maxzoom hint naming the envelope max. Identical ranges collapse to one line.
+func TestSummarizeZoomsSubsetHint(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // subset (max)
+		{convMin: 12, convMax: 16, availMin: 12, availMax: 19}, // same group
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14}, // full range
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 grouped lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "2 chart(s)") || !strings.Contains(lines[0], "z12-z16") {
+		t.Errorf("group line 0 = %q, want 2 charts converting z12-z16", lines[0])
+	}
+	if !strings.Contains(lines[0], "available z12-z19") {
+		t.Errorf("subset line should show the available range, got %q", lines[0])
+	}
+	if strings.Contains(lines[1], "available") {
+		t.Errorf("full-range line should not show an available range, got %q", lines[1])
+	}
+	if hint == "" {
+		t.Fatal("expected a hint when a group is a subset")
+	}
+	if !strings.Contains(hint, "-maxzoom 19") {
+		t.Errorf("hint should suggest -maxzoom 19, got %q", hint)
+	}
+	if strings.Contains(hint, "-minzoom") {
+		t.Errorf("hint should not mention -minzoom when only the max is a subset, got %q", hint)
+	}
+}
+
+// TestSummarizeZoomsNoHintWhenFull: when every cell covers its full available
+// range, no hint is produced and no "available" suffix is shown.
+func TestSummarizeZoomsNoHintWhenFull(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 10, convMax: 14, availMin: 10, availMax: 14},
+		{convMin: 13, convMax: 17, availMin: 13, availMax: 17},
+	}
+	lines, hint := summarizeZooms(reports)
+
+	if hint != "" {
+		t.Errorf("expected no hint when nothing is a subset, got %q", hint)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	for _, l := range lines {
+		if strings.Contains(l, "available") {
+			t.Errorf("full-range line should omit available, got %q", l)
+		}
+	}
+}
+
+// TestSummarizeZoomsMinSubset: a narrowed low end (override) yields a -minzoom hint.
+func TestSummarizeZoomsMinSubset(t *testing.T) {
+	reports := []zoomReport{
+		{convMin: 14, convMax: 16, availMin: 12, availMax: 16}, // subset (min only)
+	}
+	_, hint := summarizeZooms(reports)
+	if !strings.Contains(hint, "-minzoom 12") {
+		t.Errorf("hint should suggest -minzoom 12, got %q", hint)
+	}
+	if strings.Contains(hint, "-maxzoom") {
+		t.Errorf("hint should not mention -maxzoom when only the min is a subset, got %q", hint)
+	}
+}
+
+func TestSummarizeZoomsEmpty(t *testing.T) {
+	lines, hint := summarizeZooms(nil)
+	if lines != nil || hint != "" {
+		t.Errorf("empty input should give empty output, got lines=%v hint=%q", lines, hint)
+	}
+}

--- a/s57/correctness_test.go
+++ b/s57/correctness_test.go
@@ -1,0 +1,66 @@
+package s57
+
+import (
+	"math"
+	"testing"
+
+	"github.com/lukeroth/gdal"
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+)
+
+func TestClampToInt32(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want int32
+	}{
+		{0, 0},
+		{100.7, 100},
+		{-5.9, -5},
+		{1e18, math.MaxInt32},
+		{-1e18, math.MinInt32},
+		{math.Inf(1), math.MaxInt32},
+		{math.Inf(-1), math.MinInt32},
+		{math.NaN(), 0},
+	}
+	for _, c := range cases {
+		if got := clampToInt32(c.in); got != c.want {
+			t.Errorf("clampToInt32(%v) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// getBounds must read the cell bounds from the cached M_COVR layer without
+// opening the datasource, so a path that points nowhere still yields the bounds
+// (the old code opened and immediately destroyed a datasource it never used).
+func TestGetBoundsFromCachedLayerNoOpen(t *testing.T) {
+	env := gdal.Envelope{}
+	env.SetMinX(1)
+	env.SetMinY(2)
+	env.SetMaxX(3)
+	env.SetMaxY(4)
+	file := dataset.File{
+		Id:   "T",
+		Path: "/does/not/exist.000",
+		Layers: map[string]dataset.Layer{
+			"M_COVR": {Name: "M_COVR", Bounds: env},
+		},
+	}
+	b := getBounds(file)
+	want := []float32{1, 2, 3, 4}
+	if len(b) != 4 || b[0] != want[0] || b[1] != want[1] || b[2] != want[2] || b[3] != want[3] {
+		t.Errorf("getBounds = %v, want %v", b, want)
+	}
+	if getBounds(dataset.File{Id: "T"}) != nil {
+		t.Errorf("getBounds without M_COVR should return nil")
+	}
+}
+
+// Close must release the transform/SRS handles created in NewS57Tiler and be safe
+// to call more than once (a double Destroy of a GDAL handle would crash).
+func TestTilerCloseIdempotent(t *testing.T) {
+	for i := 0; i < 25; i++ {
+		tiler := NewS57Tiler(nil)
+		tiler.Close()
+		tiler.Close()
+	}
+}

--- a/s57/dataset/usageband.go
+++ b/s57/dataset/usageband.go
@@ -2,15 +2,14 @@ package dataset
 
 import (
 	"github.com/lukeroth/gdal"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
-// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
-// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads the
-// authoritative DSID_INTU value from the cell's DSID record. The DSID layer is
-// geometry-less and therefore excluded from File.Layers, so we open the datasource
-// and scan layers by index. Falls back to the navigational-purpose digit in the
-// cell name (3rd character, e.g. US"4"WA1JJ) and returns 0 when unknown.
-func UsageBand(file File) int {
+// dsidInfo reads the cell's DSID record once and returns the usage band
+// (DSID_INTU) and the compilation-scale denominator (DSPM_CSCL); each is 0 when
+// absent. The DSID layer is geometry-less and therefore excluded from
+// File.Layers, so we open the datasource and scan layers by index.
+func dsidInfo(file File) (intu int, cscl int) {
 	ds := gdal.OpenDataSource(file.Path, 0)
 	defer ds.Destroy()
 	for i := 0; i < ds.LayerCount(); i++ {
@@ -21,21 +20,40 @@ func UsageBand(file File) int {
 		layer.ResetReading()
 		feat := layer.NextFeature()
 		if feat != nil {
-			band := 0
 			if idx := feat.FieldIndex("DSID_INTU"); idx >= 0 && feat.IsFieldSet(idx) {
-				band = int(feat.FieldAsInteger64(idx))
+				intu = int(feat.FieldAsInteger64(idx))
+			}
+			if idx := feat.FieldIndex("DSPM_CSCL"); idx >= 0 && feat.IsFieldSet(idx) {
+				cscl = int(feat.FieldAsInteger64(idx))
 			}
 			feat.Destroy()
-			if band >= 1 && band <= 6 {
-				return band
-			}
 		}
 		break
 	}
-	if len(file.Id) >= 3 && file.Id[2] >= '1' && file.Id[2] <= '6' {
-		return int(file.Id[2] - '0')
+	return intu, cscl
+}
+
+// resolveBand maps a cell's DSID_INTU and id to a standard S-57 usage band
+// (1..6), falling back to the navigational-purpose digit in the cell name (3rd
+// character, e.g. US"4"WA1JJ) and returning 0 when neither yields 1..6 (e.g. an
+// Inland-ENC band such as 7).
+func resolveBand(intu int, id string) int {
+	if intu >= 1 && intu <= 6 {
+		return intu
+	}
+	if len(id) >= 3 && id[2] >= '1' && id[2] <= '6' {
+		return int(id[2] - '0')
 	}
 	return 0
+}
+
+// UsageBand returns the S-57 navigational purpose (usage band) of a cell:
+// 1=Overview, 2=General, 3=Coastal, 4=Approach, 5=Harbour, 6=Berthing. It reads
+// the authoritative DSID_INTU value from the cell's DSID record, falls back to
+// the navigational-purpose digit in the cell name, and returns 0 when unknown.
+func UsageBand(file File) int {
+	intu, _ := dsidInfo(file)
+	return resolveBand(intu, file.Id)
 }
 
 // BandZoom maps a usage band to a default web-map zoom range. The values are a
@@ -58,4 +76,53 @@ func BandZoom(band int) (minZoom, maxZoom int) {
 	default:
 		return 9, 14
 	}
+}
+
+// ZoomRange is the web-map zoom range a cell is tiled to by default: from a
+// sensible coarse Min up to Max, the finest zoom matching the cell's native
+// detail. There is no artificial cap — a chart is tiled to the resolution it
+// actually contains, so nothing relies on the consuming client overzooming.
+// Users can still narrow this with -minzoom/-maxzoom.
+type ZoomRange struct {
+	Min, Max int
+}
+
+// CellZoomRange returns a cell's default zoom range from a single DSID read. The
+// minimum comes from the usage band (overview charts start coarse, harbour
+// charts start fine); for an inland/unknown band it is a fixed floor. The
+// maximum is the cell's native zoom — the finest level matching its compilation
+// scale (DSPM_CSCL) — and is never capped below the band default. So a 1:2000
+// inland chart tiles up to z19 and a 1:20000 approach chart up to z16.
+func CellZoomRange(file File) ZoomRange {
+	const inlandFloor = 12 // coarse floor for inland/large-scale cells (no usage band)
+	intu, cscl := dsidInfo(file)
+	band := resolveBand(intu, file.Id)
+
+	var minZ, maxZ int
+	switch {
+	case band >= 1 && band <= 6:
+		minZ, maxZ = BandZoom(band) // marine: usage-band min and max
+	case cscl > 0:
+		minZ, maxZ = inlandFloor, int(m.ZoomForScale(int32(cscl)))
+	default:
+		minZ, maxZ = BandZoom(0) // no band, no scale -> historical 9..14
+	}
+
+	// Extend the max to the cell's native compilation scale when that is finer,
+	// so a detailed chart isn't tiled below the resolution it actually contains.
+	if cscl > 0 {
+		if native := int(m.ZoomForScale(int32(cscl))); native > maxZ {
+			maxZ = native
+		}
+	}
+	if minZ > maxZ {
+		minZ = maxZ
+	}
+	return ZoomRange{Min: minZ, Max: maxZ}
+}
+
+// CellZoom returns a cell's default web-map zoom range; see CellZoomRange.
+func CellZoom(file File) (minZoom, maxZoom int) {
+	r := CellZoomRange(file)
+	return r.Min, r.Max
 }

--- a/s57/dataset/usageband_test.go
+++ b/s57/dataset/usageband_test.go
@@ -47,3 +47,94 @@ func TestUsageBandFromDSID(t *testing.T) {
 		t.Skip("US4WA1JJ not found in sample ENC")
 	}
 }
+
+// TestCellZoom verifies per-cell zoom derivation: a marine cell keeps the
+// usage-band mapping unchanged, while a large-scale Inland ENC (DSID_INTU=7,
+// 1:2000) is tiled to a higher, scale-derived range instead of the coarse 9–14
+// default that left it blank in Freeboard. The expected (12,16) is the capped
+// derivation: ZoomForScale(2000)=19 -> cap 16, min = 16-4 floored at 12.
+func TestCellZoom(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]struct {
+		band             int
+		minZoom, maxZoom int
+	}{
+		"US4WA1JJ": {4, 10, 14}, // marine Approach: BandZoom path, unchanged
+		"1R7WAD01": {0, 12, 19}, // inland 1:2000: band 7 -> 0 -> native scale z19 (no cap)
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			if got := UsageBand(f); got != w.band {
+				t.Errorf("UsageBand(%s) = %d, want %d", f.Id, got, w.band)
+			}
+			gotMin, gotMax := CellZoom(f)
+			if gotMin != w.minZoom || gotMax != w.maxZoom {
+				t.Errorf("CellZoom(%s) = (%d,%d), want (%d,%d)", f.Id, gotMin, gotMax, w.minZoom, w.maxZoom)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}
+
+// TestCellZoomRange verifies the default range runs up to each cell's native
+// compilation scale with no cap: the inland 1:2000 cell tiles to z19, while the
+// bundled marine cells stay at their band default (which already meets/exceeds
+// their native scale).
+func TestCellZoomRange(t *testing.T) {
+	const encDir = "../../enc"
+	if _, err := os.Stat(encDir); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", encDir, err)
+	}
+	datasets, err := GetS57Datasets(encDir)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	want := map[string]ZoomRange{
+		"1R7WAD01": {Min: 12, Max: 19}, // inland 1:2000 -> native z19 (no cap)
+		"US4WA1JJ": {Min: 10, Max: 14}, // marine 1:45000 -> band default already at native z14
+		"US4WI1DP": {Min: 10, Max: 14}, // marine 1:90000 -> native z13, kept at band max 14
+	}
+
+	seen := map[string]bool{}
+	for _, ds := range datasets {
+		for _, f := range ds.Files {
+			w, ok := want[f.Id]
+			if !ok {
+				continue
+			}
+			seen[f.Id] = true
+			got := CellZoomRange(f)
+			if got != w {
+				t.Errorf("CellZoomRange(%s) = %+v, want %+v", f.Id, got, w)
+			}
+			if got.Min > got.Max {
+				t.Errorf("CellZoomRange(%s): min %d > max %d", f.Id, got.Min, got.Max)
+			}
+		}
+	}
+	for id := range want {
+		if !seen[id] {
+			t.Logf("cell %s not found in sample ENC; that assertion was skipped", id)
+		}
+	}
+}

--- a/s57/features_test.go
+++ b/s57/features_test.go
@@ -307,3 +307,40 @@ func valuesForKey(layer *vectortile.Tile_Layer, key string) []string {
 	}
 	return out
 }
+
+// TestInlandCellRendersAtZoom is the end-to-end guard for the blank Inland-ENC
+// bug. It exercises the full pipeline for a large-scale (1:2000, DSID_INTU=7)
+// cell — nested-catalog discovery through tiling — and asserts it emits feature
+// geometry at the higher zoom CellZoom now selects. The depth contours it checks
+// carry SCAMIN ~15000, the detail that was missing when these cells were tiled
+// only to z14.
+func TestInlandCellRendersAtZoom(t *testing.T) {
+	if _, err := os.Stat(sampleENC); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", sampleENC, err)
+	}
+	datasets, err := dataset.GetS57Datasets(sampleENC)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+
+	var cell *dataset.File
+	for di := range datasets {
+		for fi := range datasets[di].Files {
+			if datasets[di].Files[fi].Id == "1R7WAD01" {
+				cell = &datasets[di].Files[fi]
+			}
+		}
+	}
+	if cell == nil {
+		t.Skip("inland cell 1R7WAD01 not present in sample ENC")
+	}
+
+	const layerName = "DEPCNT" // depth contours: SCAMIN-gated, the missing detail
+	lon, lat, ok := firstFeatureCoord(cell, layerName)
+	if !ok {
+		t.Skipf("no %s feature in %s", layerName, cell.Id)
+	}
+	if l := findLayerInTiles(t, datasets, cell, lon, lat, layerName); l == nil {
+		t.Fatalf("inland cell %s produced no %s features at any zoom up to 16", cell.Id, layerName)
+	}
+}

--- a/s57/mercantile/mercantile.go
+++ b/s57/mercantile/mercantile.go
@@ -78,6 +78,8 @@ func Scale(tileid TileID) int32 {
 		return 70000
 	case 14:
 		return 35000
+	case 15:
+		return 24000
 	case 16:
 		return 15000
 	case 17:
@@ -97,6 +99,29 @@ func Scale(tileid TileID) int32 {
 	default:
 		return 0
 	}
+}
+
+// ZoomForScale returns the finest (highest) web-map zoom whose mapped scale
+// denominator (see Scale) is still >= the given chart compilation-scale
+// denominator. It is the inverse of Scale: a 1:2000 chart (scaleDenominator =
+// 2000) resolves to the zoom its detail is authored for. It is driven off the
+// same Scale table so the mapping lives in exactly one place.
+//
+// Scale denominators decrease as zoom increases, so we walk zoom upward and stop
+// at the first level whose Scale is <= the requested denominator. A non-positive
+// denominator (e.g. missing DSPM_CSCL) yields 0; a denominator finer than the
+// table's deepest entry clamps to that deepest zoom.
+func ZoomForScale(scaleDenominator int32) uint64 {
+	if scaleDenominator <= 0 {
+		return 0
+	}
+	const maxTableZoom = 23 // deepest zoom Scale defines
+	for z := uint64(0); z <= maxTableZoom; z++ {
+		if Scale(TileID{Z: z}) <= scaleDenominator {
+			return z
+		}
+	}
+	return maxTableZoom
 }
 
 // Returns the (x, y, z) tile.

--- a/s57/mercantile/mercantile.go
+++ b/s57/mercantile/mercantile.go
@@ -130,7 +130,24 @@ func Tile(lng float64, lat float64, zoom int) TileID {
 	n := math.Pow(2.0, float64(zoom))
 	xtile := int(math.Floor((lng + 180.0) / 360.0 * n))
 	ytile := int(math.Floor((1.0 - math.Log(math.Tan(lat)+(1.0/math.Cos(lat)))/math.Pi) / 2.0 * n))
+	// Clamp to the valid [0, 2^zoom) grid. At the antimeridian (lng=180) the x
+	// math lands exactly on 2^zoom (one past the last column), and latitudes past
+	// the Web-Mercator limit drive y out of range; either would make callers like
+	// GetTilesForBounds iterate off-grid and emit invalid tiles.
+	max := int(n) - 1
+	xtile = clampTileIndex(xtile, max)
+	ytile = clampTileIndex(ytile, max)
 	return TileID{int64(xtile), int64(ytile), uint64(zoom)}
+}
+
+func clampTileIndex(v, max int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > max {
+		return max
+	}
+	return v
 }
 
 // Returns in string format like a geohash would be

--- a/s57/mercantile/mercantile_test.go
+++ b/s57/mercantile/mercantile_test.go
@@ -1,0 +1,64 @@
+package mercantile
+
+import (
+	"math"
+	"testing"
+)
+
+// TestScaleNoZeroGapsMonotonic guards the scale table: every zoom z0..z23 must
+// map to a positive, strictly-decreasing denominator. This catches a missing
+// case (e.g. z15 previously fell through to the default 0, which broke the
+// SCAMIN/SCAMAX comparison in includeFeatureInTile at that zoom).
+func TestScaleNoZeroGapsMonotonic(t *testing.T) {
+	prev := int32(math.MaxInt32)
+	for z := uint64(0); z <= 23; z++ {
+		s := Scale(TileID{Z: z})
+		if s <= 0 {
+			t.Errorf("Scale(z=%d) = %d; want > 0 (no gaps z0..z23)", z, s)
+		}
+		if s >= prev {
+			t.Errorf("Scale not strictly decreasing at z=%d: %d >= %d", z, s, prev)
+		}
+		prev = s
+	}
+	if got := Scale(TileID{Z: 15}); got != 24000 {
+		t.Errorf("Scale(z=15) = %d; want 24000", got)
+	}
+}
+
+// TestZoomForScale locks the Scale inverse, including the clamps for a
+// missing/garbage compilation scale and out-of-table denominators.
+func TestZoomForScale(t *testing.T) {
+	cases := []struct {
+		scale int32
+		want  uint64
+	}{
+		{2000, 19},
+		{4000, 18},
+		{8000, 17},
+		{15000, 16},
+		{24000, 15},
+		{35000, 14},
+		{90000, 13},
+		{0, 0},         // missing DSPM_CSCL
+		{-5, 0},        // garbage
+		{1, 23},        // finer than the table -> deepest zoom
+		{600000000, 0}, // coarser than z0 -> 0
+	}
+	for _, c := range cases {
+		if got := ZoomForScale(c.scale); got != c.want {
+			t.Errorf("ZoomForScale(%d) = %d; want %d", c.scale, got, c.want)
+		}
+	}
+}
+
+// TestZoomForScaleRoundTrips ties Scale and ZoomForScale together: because the
+// table is gap-free and strictly decreasing, the inverse is exact at every table
+// point, so the two functions cannot drift apart.
+func TestZoomForScaleRoundTrips(t *testing.T) {
+	for z := uint64(0); z <= 23; z++ {
+		if got := ZoomForScale(Scale(TileID{Z: z})); got != z {
+			t.Errorf("ZoomForScale(Scale(z=%d)) = %d; want %d", z, got, z)
+		}
+	}
+}

--- a/s57/mercantile/tile_grid_test.go
+++ b/s57/mercantile/tile_grid_test.go
@@ -1,0 +1,30 @@
+package mercantile
+
+import "testing"
+
+// Tile must never return an x/y outside the [0, 2^z) grid, even at the
+// antimeridian / poles where the projection math lands exactly on (or past) the
+// edge. GetTilesForBounds iterates col=ulTile.X..lrTile.X, so an off-grid value
+// produced invalid/wrong tiles.
+func TestTileClampsToGrid(t *testing.T) {
+	for _, z := range []int{0, 1, 5, 14, 23} {
+		max := int64(1)<<uint(z) - 1
+		for _, lng := range []float64{180.0, -180.0, 360.0, -360.0} {
+			got := Tile(lng, 0.0, z)
+			if got.X < 0 || got.X > max {
+				t.Errorf("Tile(%v,0,%d).X = %d, want in [0,%d]", lng, z, got.X, max)
+			}
+		}
+		// A latitude beyond the Web-Mercator limit must also stay on-grid.
+		if got := Tile(0.0, 89.9, z); got.Y < 0 || got.Y > max {
+			t.Errorf("Tile(0,89.9,%d).Y = %d, want in [0,%d]", z, got.Y, max)
+		}
+	}
+}
+
+// An interior coordinate is unaffected by the clamp.
+func TestTileInteriorUnchanged(t *testing.T) {
+	if got := Tile(0.0, 0.0, 2); got != (TileID{X: 2, Y: 2, Z: 2}) {
+		t.Errorf("Tile(0,0,2) = %+v, want {2,2,2}", got)
+	}
+}

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -43,7 +43,10 @@ type Value struct {
 }
 
 type s57Tiler struct {
+	srcRef    gdal.SpatialReference
+	dstRef    gdal.SpatialReference
 	transform gdal.CoordinateTransform
+	closed    bool
 	datasets  []dataset.Dataset
 	valuesMap map[string]uint32
 	values    []Value
@@ -87,13 +90,21 @@ func (s *s57Tiler) datasource(path string) gdal.DataSource {
 	return s.ds
 }
 
-// Close releases the cached datasource. A worker must defer this when its tiler is
-// done; the tiler must not be used afterwards.
+// Close releases the cached datasource and the coordinate-transform / spatial-
+// reference handles created in NewS57Tiler. A worker must defer this when its
+// tiler is done; the tiler must not be used afterwards. Safe to call more than once.
 func (s *s57Tiler) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
 	if s.dsOpen {
 		s.ds.Destroy()
 		s.dsOpen = false
 	}
+	s.transform.Destroy()
+	s.srcRef.Destroy()
+	s.dstRef.Destroy()
 }
 
 func NewS57Tiler(datasets []dataset.Dataset) *s57Tiler {
@@ -103,6 +114,8 @@ func NewS57Tiler(datasets []dataset.Dataset) *s57Tiler {
 	dst.FromEPSG(3857)
 
 	return &s57Tiler{
+		srcRef:    src,
+		dstRef:    dst,
 		transform: gdal.CreateCoordinateTransform(src, dst),
 		datasets:  datasets,
 		bx:        make([]float64, 1),
@@ -152,7 +165,23 @@ func (s *s57Tiler) toTileCoordinate(tileBounds m.Extrema, x float64, y float64, 
 	tx, ty := s.to3857(x, y)
 	xx := (tx - s.ulx) * s.xf
 	yy := (s.uly - ty) * s.yf
-	return int32(xx), int32(yy), 0
+	return clampToInt32(xx), clampToInt32(yy), 0
+}
+
+// clampToInt32 converts a tile-space coordinate to int32 without silently
+// wrapping: a pathological geometry or projection result (or NaN/±Inf) would
+// otherwise overflow the cast and produce a bogus tile coordinate.
+func clampToInt32(v float64) int32 {
+	switch {
+	case math.IsNaN(v):
+		return 0
+	case v >= math.MaxInt32:
+		return math.MaxInt32
+	case v <= math.MinInt32:
+		return math.MinInt32
+	default:
+		return int32(v)
+	}
 }
 
 func getCommand(command int, count int) uint32 {
@@ -506,20 +535,19 @@ func (s *s57Tiler) GetTiles(file dataset.File, zoomLevel int) map[string]m.TileI
 }
 
 func getBounds(file dataset.File) []float32 {
-
-	var bounds []float32
+	// The M_COVR extent is already cached on the File (populated at discovery), so
+	// read it directly. The previous version opened and immediately destroyed a
+	// datasource here without ever using it — pure wasted I/O on every metadata write.
 	layer, ok := file.Layers["M_COVR"]
-	if ok {
-		datasource := gdal.OpenDataSource(file.Path, 0)
-		defer datasource.Destroy()
-		bounds = make([]float32, 4)
-		bounds[0] = float32(layer.Bounds.MinX())
-		bounds[1] = float32(layer.Bounds.MinY())
-		bounds[2] = float32(layer.Bounds.MaxX())
-		bounds[3] = float32(layer.Bounds.MaxY())
+	if !ok {
+		return nil
 	}
-
-	return bounds
+	return []float32{
+		float32(layer.Bounds.MinX()),
+		float32(layer.Bounds.MinY()),
+		float32(layer.Bounds.MaxX()),
+		float32(layer.Bounds.MaxY()),
+	}
 }
 
 func (s *s57Tiler) GenerateMetaData(outPath string, dataset dataset.Dataset, file dataset.File, minZoom int, maxZoom int) {


### PR DESCRIPTION
## Why

Four independent issues in `s57tiler.go` / `mercantile.go`:

- **Antimeridian / pole off-grid:** `Tile(lng,lat,z)` computed `x = floor((lng+180)/360 * 2^z)` with no clamp, so `Tile(180,…)` returns `x = 2^z` — one past the last column `[0, 2^z)` — and latitudes past the Web-Mercator limit produce a negative `y`. `GetTilesForBounds` iterates `col = ulTile.X .. lrTile.X`, so an off-grid value yields invalid/wrong tiles.
- **int32 wrap:** `toTileCoordinate` cast the projected coordinate straight to `int32`. A pathological geometry/projection result (or `NaN`/`±Inf`) silently wraps to a bogus coordinate.
- **`getBounds` wasted I/O:** it opened *and immediately destroyed* a GDAL datasource it never used — the bounds were read from the cached `M_COVR` layer the whole time. That's one pointless open/close on every metadata write.
- **SRS/transform leak:** `NewS57Tiler` creates two `SpatialReference`s and a `CoordinateTransform`, but `Close()` only freed the cached datasource — the SRS pair and the
  transform leaked. `NewS57Tiler` is called per worker per work-unit, so this leaks across hundreds of tiler lifecycles per run.

## What changed

- `Tile()` clamps `x`/`y` into `[0, 2^z)` (new `clampTileIndex` helper).
- `toTileCoordinate` uses a new `clampToInt32` that handles range + `NaN`/`±Inf`.
- `getBounds` reads the cached `M_COVR` extent directly and no longer touches GDAL.
- `Close()` now also destroys the `CoordinateTransform` and both `SpatialReference`s, and is
  idempotent (a `closed` guard prevents a double-free if it's called twice).

## Tests

- `s57/mercantile/tile_grid_test.go` (new): `TestTileClampsToGrid` (antimeridian + beyond ±180 + high latitude across z0..z23 stay on-grid) and `TestTileInteriorUnchanged`. Written test-first (committed red — `Tile(180,0,23).X` was `8388608`).
- `s57/correctness_test.go` (new): `TestClampToInt32` (range, `NaN`, `±Inf` — committed red, function undefined); `TestGetBoundsFromCachedLayerNoOpen` (bounds come from the layer even when `Path` points nowhere; no `M_COVR` → nil); `TestTilerCloseIdempotent` (25× create + double-Close, exercising the new Destroy calls without a double-free).

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` green (incl. the tile output-stability fingerprint — interior tiles unchanged) · `go test -race ./s57/` clean.

## Notes

- The SRS/transform leak isn't unit-asserted as a leak — `TestTilerCloseIdempotent` exercises the release path and guards against a double-free, but a true leak assertion isn't portable. Verified by reading + the suite passing.
- `Tile_Geohash` duplicates the same projection math but is unused; left untouched here (slated for dead-code removal in `chore/dx-polish`).