### PR TITLE
Merge 1st - Feat: operator-safety validation, --dry-run, SIGINT handling, and zoom docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,27 @@ s57-tiler --in <directory of S-57 ENCs> --out <output directory>
 |------|---------|-------------|
 | `-in` | `./charts` | Directory tree of S-57 ENCs (contains `catalog.031`) |
 | `-out` | `./static/charts` | Output directory for vector tiles |
-| `-minzoom` | `9` | Minimum zoom level |
-| `-maxzoom` | `14` | Maximum zoom level |
+| `-minzoom` | per-chart | Override the minimum zoom for every chart (see [Zoom levels](#zoom-levels)) |
+| `-maxzoom` | per-chart | Override the maximum zoom for every chart (clamped to z0–z23) |
 | `-bounds` | — | Limit output to a bounding box: `W,N,E,S` |
 | `-at` | — | Generate only the tile at `lon,lat` |
 | `-workers` | CPUs − 1 | Number of parallel tile workers |
+| `-dry-run` | `false` | Scan and report the tile count, then exit without writing |
 | `-debug` | `false` | Show debug info (don't suppress GDAL errors) |
+
+### Zoom levels
+
+By default (no `-minzoom`/`-maxzoom`), **each chart is tiled to its own native zoom range** —
+from a sensible coarse floor up to the level matching the chart's compilation scale. A small-scale
+overview chart might only go to ~z12, while a large-scale harbour or Inland ENC chart (e.g. 1:2,000)
+is tiled all the way to ~z19, because that's the detail it actually contains. Before tiling, the run
+prints each chart's converting-vs-available range and the total tile count.
+
+Passing `-minzoom` and/or `-maxzoom` overrides this with a fixed range applied to every chart
+(clamped to the supported z0–z23). Use this to cap output: tiling large-scale charts to native zoom
+can produce **a lot** of tiles — a 20-cell Inland ENC set reached ~3.7 million tiles (hours) at
+native z19 versus ~62k capped at z16. Run with `-dry-run` first to see the count, then pass
+`-maxzoom N` to cap it if needed.
 
 ## Building from source
 

--- a/cmd/s57-tiler/args.go
+++ b/cmd/s57-tiler/args.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// maxSupportedZoom is the deepest zoom the mercantile.Scale table defines; beyond
+// it the SCAMIN/SCAMAX filtering degrades, so explicit flags are clamped to it.
+const maxSupportedZoom = 23
+
+// clampZoomValue clamps a zoom flag into [0, maxSupportedZoom] and returns a note
+// (empty when in range) explaining any adjustment.
+func clampZoomValue(name string, z int) (int, string) {
+	switch {
+	case z < 0:
+		return 0, fmt.Sprintf("Note: -%s %d is below 0; clamped to 0.", name, z)
+	case z > maxSupportedZoom:
+		return maxSupportedZoom, fmt.Sprintf("Note: -%s %d exceeds the supported maximum z%d; clamped.", name, z, maxSupportedZoom)
+	}
+	return z, ""
+}
+
+// validateZoomRange rejects an inverted range, which would silently generate zero
+// tiles and exit "successfully".
+func validateZoomRange(minZoom, maxZoom int) error {
+	if minZoom > maxZoom {
+		return fmt.Errorf("-minzoom %d is greater than -maxzoom %d; nothing would be generated", minZoom, maxZoom)
+	}
+	return nil
+}
+
+// parseBounds parses a "W,N,E,S" bounds string and validates that it is a sane
+// geographic box (four numbers, lon in [-180,180], lat in [-90,90], W<E, S<N) so
+// a reversed or out-of-range box doesn't silently yield empty output.
+func parseBounds(s string) (m.Extrema, error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return m.Extrema{}, fmt.Errorf("bounds must be W,N,E,S (4 comma-separated numbers), got %q", s)
+	}
+	vals := make([]float64, 4)
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return m.Extrema{}, fmt.Errorf("bounds value %q is not a number", p)
+		}
+		vals[i] = v
+	}
+	b := m.Extrema{W: vals[0], N: vals[1], E: vals[2], S: vals[3]}
+	if b.W < -180 || b.W > 180 || b.E < -180 || b.E > 180 {
+		return m.Extrema{}, fmt.Errorf("bounds longitude out of range [-180,180]: W=%g E=%g", b.W, b.E)
+	}
+	if b.N < -90 || b.N > 90 || b.S < -90 || b.S > 90 {
+		return m.Extrema{}, fmt.Errorf("bounds latitude out of range [-90,90]: N=%g S=%g", b.N, b.S)
+	}
+	if b.W >= b.E {
+		return m.Extrema{}, fmt.Errorf("bounds west (%g) must be less than east (%g)", b.W, b.E)
+	}
+	if b.S >= b.N {
+		return m.Extrema{}, fmt.Errorf("bounds south (%g) must be less than north (%g)", b.S, b.N)
+	}
+	return b, nil
+}
+
+// ensureWritableDir creates the output directory if needed and probes that it is
+// writable, so a bad -out fails immediately instead of after the (possibly long)
+// scan and partway into tiling.
+func ensureWritableDir(path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("output directory %q: %w", path, err)
+	}
+	probe := filepath.Join(path, ".s57-tiler-write-test")
+	if err := os.WriteFile(probe, []byte{}, 0644); err != nil {
+		return fmt.Errorf("output directory %q is not writable: %w", path, err)
+	}
+	os.Remove(probe)
+	return nil
+}

--- a/cmd/s57-tiler/args_test.go
+++ b/cmd/s57-tiler/args_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClampZoomValue(t *testing.T) {
+	cases := []struct {
+		in       int
+		want     int
+		wantNote bool
+	}{
+		{-1, 0, true},
+		{0, 0, false},
+		{14, 14, false},
+		{23, 23, false},
+		{30, 23, true},
+	}
+	for _, c := range cases {
+		got, note := clampZoomValue("maxzoom", c.in)
+		if got != c.want || (note != "") != c.wantNote {
+			t.Errorf("clampZoomValue(%d) = (%d, note=%q), want (%d, hasNote=%v)", c.in, got, note, c.want, c.wantNote)
+		}
+	}
+}
+
+func TestValidateZoomRange(t *testing.T) {
+	if err := validateZoomRange(9, 14); err != nil {
+		t.Errorf("validateZoomRange(9,14) = %v, want nil", err)
+	}
+	if err := validateZoomRange(5, 5); err != nil {
+		t.Errorf("validateZoomRange(5,5) = %v, want nil", err)
+	}
+	if err := validateZoomRange(20, 5); err == nil {
+		t.Error("validateZoomRange(20,5) = nil, want error")
+	}
+}
+
+func TestParseBounds(t *testing.T) {
+	b, err := parseBounds("5,50,6,49") // W,N,E,S
+	if err != nil {
+		t.Fatalf("parseBounds valid: %v", err)
+	}
+	if b.W != 5 || b.N != 50 || b.E != 6 || b.S != 49 {
+		t.Errorf("parseBounds = %+v, want W5 N50 E6 S49", b)
+	}
+
+	bad := []string{
+		"1,2,3",       // wrong count
+		"a,2,3,4",     // not a number
+		"6,50,5,49",   // W >= E
+		"5,49,6,50",   // S >= N
+		"200,50,6,49", // lon out of range
+		"5,95,6,49",   // lat out of range
+	}
+	for _, s := range bad {
+		if _, err := parseBounds(s); err == nil {
+			t.Errorf("parseBounds(%q) = nil error, want error", s)
+		}
+	}
+}
+
+func TestEnsureWritableDir(t *testing.T) {
+	if err := ensureWritableDir(filepath.Join(t.TempDir(), "sub", "charts")); err != nil {
+		t.Errorf("ensureWritableDir(new dir) = %v, want nil", err)
+	}
+	// A path whose parent is a regular file can't be created (ENOTDIR), even as
+	// root — so this is a portable "not writable" case.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureWritableDir(filepath.Join(blocker, "charts")); err == nil {
+		t.Error("ensureWritableDir(under a file) = nil, want error")
+	}
+}

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
-	"github.com/lukeroth/gdal"
-	"github.com/wdantuma/s57-tiler/s57"
-	"github.com/wdantuma/s57-tiler/s57/dataset"
-	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 	"log"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
+
+	"github.com/lukeroth/gdal"
+	"github.com/wdantuma/s57-tiler/s57"
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
 func main() {
@@ -34,6 +38,7 @@ func main() {
 	debug := flag.Bool("debug", false, "Show debug info")
 	at := flag.String("at", "", "lon,lat")
 	workers := flag.Int("workers", runtime.NumCPU()-1, "Number of parallel tile workers") // keep one CPU available for system responsiveness
+	dryRun := flag.Bool("dry-run", false, "Scan and report the tile count, then exit without writing any tiles")
 	flag.Parse()
 
 	if *workers < 1 {
@@ -42,19 +47,26 @@ func main() {
 
 	// The scale table (mercantile.Scale) is defined for z0..z23; beyond it the
 	// SCAMIN/SCAMAX filtering degrades, so clamp explicit flags into range.
-	const maxSupportedZoom = 23
-	clampZoom := func(name string, zp *int) {
-		switch {
-		case *zp < 0:
-			fmt.Printf("Note: -%s %d is below 0; clamped to 0.\n", name, *zp)
-			*zp = 0
-		case *zp > maxSupportedZoom:
-			fmt.Printf("Note: -%s %d exceeds the supported maximum z%d; clamped.\n", name, *zp, maxSupportedZoom)
-			*zp = maxSupportedZoom
+	applyClamp := func(name string, zp *int) {
+		v, note := clampZoomValue(name, *zp)
+		*zp = v
+		if note != "" {
+			fmt.Println(note)
 		}
 	}
-	clampZoom("minzoom", minzoom)
-	clampZoom("maxzoom", maxzoom)
+	applyClamp("minzoom", minzoom)
+	applyClamp("maxzoom", maxzoom)
+	if err := validateZoomRange(*minzoom, *maxzoom); err != nil {
+		log.Fatal(err)
+	}
+
+	// Fail fast if the output directory can't be created/written, before the
+	// (possibly long) scan and tiling. Skipped for a dry run, which writes nothing.
+	if !*dryRun {
+		if err := ensureWritableDir(*outputPath); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	// Honor explicit -minzoom/-maxzoom; otherwise the zoom range is derived per cell
 	// from its S-57 usage band (overview→berthing) in the pre-pass below.
@@ -84,27 +96,11 @@ func main() {
 
 	var bounds *m.Extrema = nil
 	if *boundsFlag != "" {
-		bounds = &m.Extrema{}
-		parts := strings.Split(*boundsFlag, ",")
-		if len(parts) != 4 {
-			log.Fatal("Invalid bounds")
+		b, err := parseBounds(*boundsFlag)
+		if err != nil {
+			log.Fatal(err)
 		}
-		for i, p := range parts {
-			if v, err := strconv.ParseFloat(p, 64); err == nil {
-				switch i {
-				case 0:
-					bounds.W = v
-				case 1:
-					bounds.N = v
-				case 2:
-					bounds.E = v
-				case 3:
-					bounds.S = v
-				}
-			} else {
-				log.Fatal("Invalid bounds")
-			}
-		}
+		bounds = &b
 	}
 
 	var tile *m.TileID = nil
@@ -123,6 +119,11 @@ func main() {
 			log.Fatal("Invalid at")
 		}
 	}
+
+	// Cancel cleanly on Ctrl-C / SIGTERM so an interrupted run stops feeding work
+	// instead of being killed mid-write.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	tiler := s57.NewS57Tiler(datasets)
 
@@ -181,9 +182,19 @@ func main() {
 	// can be very large, so surface the count before the (possibly long) tiling.
 	fmt.Printf("Generating %d tiles\n", grandTotal)
 
+	// A dry run reports the plan (zoom ranges + tile count) and stops before writing,
+	// so a wrong dataset/zoom is caught without committing to a multi-hour run.
+	if *dryRun {
+		fmt.Println("Dry run: no tiles written.")
+		return
+	}
+
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()
 	for _, wu := range work {
+		if ctx.Err() != nil {
+			break
+		}
 		prog.setStage(fmt.Sprintf("%s, Zoom: %d", wu.file.Id, wu.z))
 
 		jobs := make(chan m.TileID, *workers*2)
@@ -204,13 +215,21 @@ func main() {
 			}()
 		}
 		for _, t := range wu.tiles {
-			jobs <- t
+			select {
+			case jobs <- t:
+			case <-ctx.Done():
+			}
 		}
 		close(jobs)
 		wg.Wait()
 		tiler.GenerateMetaData(*outputPath, wu.dataset, wu.file, wu.minzoom, wu.maxzoom)
 	}
 	prog.finish()
+
+	if ctx.Err() != nil {
+		fmt.Fprintln(os.Stderr, "Interrupted; output is incomplete.")
+		os.Exit(130)
+	}
 }
 
 // workUnit is the tile set for a single (dataset, file, zoom), materialized during


### PR DESCRIPTION
## Why

The CLI happily committed to long runs on bad input and gave the operator no safe way to preview or stop one:

- `-minzoom 20 -maxzoom 5` silently produced zero tiles and exited **0** ("success").
- `-bounds` accepted reversed or out-of-range boxes (`W>=E`, `S>=N`, `|lon|>180`) → empty/unexpected output.
- An unwritable `-out` wasn't discovered until the first tile write — after the whole scan and partway into tiling.
- Ctrl-C killed the process mid-write, leaving partial `.pbf`/`metadata.json` with no clean stop.
- There was no way to preview a run; native-zoom over large-scale charts can be millions of tiles (hours), and the README still implied a fixed 9–14 range and never documented the native default.

## What changed

- **Validation:** `-minzoom <= -maxzoom` is enforced after clamping; `-bounds` is fully validated (count, numeric, lon/lat ranges, `W<E`, `S<N`). Both fail fast with a clear message before any scan.
- **`-out` pre-flight:** the output dir is created and probe-written up front (skipped for `--dry-run`).
- **`--dry-run`:** scans, prints the zoom plan + total tile count, and exits without writing — preview a large run before committing. (Chose a flag over an interactive prompt so it stays automation/CI-friendly.)
- **Signals:** `SIGINT`/`SIGTERM` cancel a context; the worker loop stops feeding work and exits `130` with `Interrupted; output is incomplete.` instead of being killed mid-write.
- **Helpers extracted** to `cmd/s57-tiler/args.go` (`clampZoomValue`, `validateZoomRange`, `parseBounds`, `ensureWritableDir`) so the validation is unit-tested.
- **README:** documents the native-zoom default, the `-minzoom/-maxzoom` override, the tile-count magnitude (~3.7M for the Waddenzee set vs ~62k at z16), and `-dry-run`.

## Tests

- `cmd/s57-tiler/args_test.go` (new, hermetic), written test-first: `clampZoomValue`, `validateZoomRange`, `parseBounds` (count / numeric / `W<E` / `S<N` / lon / lat cases), `ensureWritableDir` (new dir OK; under-a-file fails portably, incl. as root).
- Manual CLI smoke (against the bundled `enc/`): inverted zoom and bad bounds/`-out` fail fast with exit 1 (no scan); `--dry-run` prints `Generating 117 tiles` + `Dry run: no tiles written.`, exits 0, and creates nothing.

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` green.