### PR TITLE
Merge 2nd - Perf: scale the tiler to native-zoom workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,27 @@ s57-tiler --in <directory of S-57 ENCs> --out <output directory>
 |------|---------|-------------|
 | `-in` | `./charts` | Directory tree of S-57 ENCs (contains `catalog.031`) |
 | `-out` | `./static/charts` | Output directory for vector tiles |
-| `-minzoom` | `9` | Minimum zoom level |
-| `-maxzoom` | `14` | Maximum zoom level |
+| `-minzoom` | per-chart | Override the minimum zoom for every chart (see [Zoom levels](#zoom-levels)) |
+| `-maxzoom` | per-chart | Override the maximum zoom for every chart (clamped to z0–z23) |
 | `-bounds` | — | Limit output to a bounding box: `W,N,E,S` |
 | `-at` | — | Generate only the tile at `lon,lat` |
 | `-workers` | CPUs − 1 | Number of parallel tile workers |
+| `-dry-run` | `false` | Scan and report the tile count, then exit without writing |
 | `-debug` | `false` | Show debug info (don't suppress GDAL errors) |
+
+### Zoom levels
+
+By default (no `-minzoom`/`-maxzoom`), **each chart is tiled to its own native zoom range** —
+from a sensible coarse floor up to the level matching the chart's compilation scale. A small-scale
+overview chart might only go to ~z12, while a large-scale harbour or Inland ENC chart (e.g. 1:2,000)
+is tiled all the way to ~z19, because that's the detail it actually contains. Before tiling, the run
+prints each chart's converting-vs-available range and the total tile count.
+
+Passing `-minzoom` and/or `-maxzoom` overrides this with a fixed range applied to every chart
+(clamped to the supported z0–z23). Use this to cap output: tiling large-scale charts to native zoom
+can produce **a lot** of tiles — a 20-cell Inland ENC set reached ~3.7 million tiles (hours) at
+native z19 versus ~62k capped at z16. Run with `-dry-run` first to see the count, then pass
+`-maxzoom N` to cap it if needed.
 
 ## Building from source
 

--- a/cmd/s57-tiler/args.go
+++ b/cmd/s57-tiler/args.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// maxSupportedZoom is the deepest zoom the mercantile.Scale table defines; beyond
+// it the SCAMIN/SCAMAX filtering degrades, so explicit flags are clamped to it.
+const maxSupportedZoom = 23
+
+// clampZoomValue clamps a zoom flag into [0, maxSupportedZoom] and returns a note
+// (empty when in range) explaining any adjustment.
+func clampZoomValue(name string, z int) (int, string) {
+	switch {
+	case z < 0:
+		return 0, fmt.Sprintf("Note: -%s %d is below 0; clamped to 0.", name, z)
+	case z > maxSupportedZoom:
+		return maxSupportedZoom, fmt.Sprintf("Note: -%s %d exceeds the supported maximum z%d; clamped.", name, z, maxSupportedZoom)
+	}
+	return z, ""
+}
+
+// validateZoomRange rejects an inverted range, which would silently generate zero
+// tiles and exit "successfully".
+func validateZoomRange(minZoom, maxZoom int) error {
+	if minZoom > maxZoom {
+		return fmt.Errorf("-minzoom %d is greater than -maxzoom %d; nothing would be generated", minZoom, maxZoom)
+	}
+	return nil
+}
+
+// parseBounds parses a "W,N,E,S" bounds string and validates that it is a sane
+// geographic box (four numbers, lon in [-180,180], lat in [-90,90], W<E, S<N) so
+// a reversed or out-of-range box doesn't silently yield empty output.
+func parseBounds(s string) (m.Extrema, error) {
+	parts := strings.Split(s, ",")
+	if len(parts) != 4 {
+		return m.Extrema{}, fmt.Errorf("bounds must be W,N,E,S (4 comma-separated numbers), got %q", s)
+	}
+	vals := make([]float64, 4)
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil {
+			return m.Extrema{}, fmt.Errorf("bounds value %q is not a number", p)
+		}
+		vals[i] = v
+	}
+	b := m.Extrema{W: vals[0], N: vals[1], E: vals[2], S: vals[3]}
+	if b.W < -180 || b.W > 180 || b.E < -180 || b.E > 180 {
+		return m.Extrema{}, fmt.Errorf("bounds longitude out of range [-180,180]: W=%g E=%g", b.W, b.E)
+	}
+	if b.N < -90 || b.N > 90 || b.S < -90 || b.S > 90 {
+		return m.Extrema{}, fmt.Errorf("bounds latitude out of range [-90,90]: N=%g S=%g", b.N, b.S)
+	}
+	if b.W >= b.E {
+		return m.Extrema{}, fmt.Errorf("bounds west (%g) must be less than east (%g)", b.W, b.E)
+	}
+	if b.S >= b.N {
+		return m.Extrema{}, fmt.Errorf("bounds south (%g) must be less than north (%g)", b.S, b.N)
+	}
+	return b, nil
+}
+
+// ensureWritableDir creates the output directory if needed and probes that it is
+// writable, so a bad -out fails immediately instead of after the (possibly long)
+// scan and partway into tiling.
+func ensureWritableDir(path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("output directory %q: %w", path, err)
+	}
+	probe := filepath.Join(path, ".s57-tiler-write-test")
+	if err := os.WriteFile(probe, []byte{}, 0644); err != nil {
+		return fmt.Errorf("output directory %q is not writable: %w", path, err)
+	}
+	os.Remove(probe)
+	return nil
+}

--- a/cmd/s57-tiler/args_test.go
+++ b/cmd/s57-tiler/args_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClampZoomValue(t *testing.T) {
+	cases := []struct {
+		in       int
+		want     int
+		wantNote bool
+	}{
+		{-1, 0, true},
+		{0, 0, false},
+		{14, 14, false},
+		{23, 23, false},
+		{30, 23, true},
+	}
+	for _, c := range cases {
+		got, note := clampZoomValue("maxzoom", c.in)
+		if got != c.want || (note != "") != c.wantNote {
+			t.Errorf("clampZoomValue(%d) = (%d, note=%q), want (%d, hasNote=%v)", c.in, got, note, c.want, c.wantNote)
+		}
+	}
+}
+
+func TestValidateZoomRange(t *testing.T) {
+	if err := validateZoomRange(9, 14); err != nil {
+		t.Errorf("validateZoomRange(9,14) = %v, want nil", err)
+	}
+	if err := validateZoomRange(5, 5); err != nil {
+		t.Errorf("validateZoomRange(5,5) = %v, want nil", err)
+	}
+	if err := validateZoomRange(20, 5); err == nil {
+		t.Error("validateZoomRange(20,5) = nil, want error")
+	}
+}
+
+func TestParseBounds(t *testing.T) {
+	b, err := parseBounds("5,50,6,49") // W,N,E,S
+	if err != nil {
+		t.Fatalf("parseBounds valid: %v", err)
+	}
+	if b.W != 5 || b.N != 50 || b.E != 6 || b.S != 49 {
+		t.Errorf("parseBounds = %+v, want W5 N50 E6 S49", b)
+	}
+
+	bad := []string{
+		"1,2,3",       // wrong count
+		"a,2,3,4",     // not a number
+		"6,50,5,49",   // W >= E
+		"5,49,6,50",   // S >= N
+		"200,50,6,49", // lon out of range
+		"5,95,6,49",   // lat out of range
+	}
+	for _, s := range bad {
+		if _, err := parseBounds(s); err == nil {
+			t.Errorf("parseBounds(%q) = nil error, want error", s)
+		}
+	}
+}
+
+func TestEnsureWritableDir(t *testing.T) {
+	if err := ensureWritableDir(filepath.Join(t.TempDir(), "sub", "charts")); err != nil {
+		t.Errorf("ensureWritableDir(new dir) = %v, want nil", err)
+	}
+	// A path whose parent is a regular file can't be created (ENOTDIR), even as
+	// root — so this is a portable "not writable" case.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureWritableDir(filepath.Join(blocker, "charts")); err == nil {
+		t.Error("ensureWritableDir(under a file) = nil, want error")
+	}
+}

--- a/cmd/s57-tiler/filework_test.go
+++ b/cmd/s57-tiler/filework_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+func TestFileWorkTileCount(t *testing.T) {
+	world := m.Extrema{W: -179, N: 85, E: 179, S: -85}
+	if got := (fileWork{minzoom: 0, maxzoom: 0, extents: []m.Extrema{world}}).tileCount(); got != 1 {
+		t.Errorf("tileCount(world, z0) = %d, want 1", got)
+	}
+	// -at mode: exactly one tile regardless of the zoom range.
+	tile := m.TileID{X: 1, Y: 2, Z: 3}
+	if got := (fileWork{single: &tile, minzoom: 0, maxzoom: 5}).tileCount(); got != 1 {
+		t.Errorf("tileCount(single) = %d, want 1", got)
+	}
+}
+
+// streamTiles must return promptly when the context is cancelled rather than block
+// forever on a full channel, so Ctrl-C stops a run cleanly.
+func TestFileWorkStreamTilesStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fw := fileWork{minzoom: 0, maxzoom: 5, extents: []m.Extrema{{W: -179, N: 85, E: 179, S: -85}}}
+	jobs := make(chan m.TileID) // unbuffered, no consumer -> sends would block
+	done := make(chan struct{})
+	go func() {
+		fw.streamTiles(ctx, jobs)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamTiles did not stop on a cancelled context")
+	}
+}

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
-	"github.com/lukeroth/gdal"
-	"github.com/wdantuma/s57-tiler/s57"
-	"github.com/wdantuma/s57-tiler/s57/dataset"
-	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 	"log"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
+
+	"github.com/lukeroth/gdal"
+	"github.com/wdantuma/s57-tiler/s57"
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
 func main() {
@@ -34,6 +38,7 @@ func main() {
 	debug := flag.Bool("debug", false, "Show debug info")
 	at := flag.String("at", "", "lon,lat")
 	workers := flag.Int("workers", runtime.NumCPU()-1, "Number of parallel tile workers") // keep one CPU available for system responsiveness
+	dryRun := flag.Bool("dry-run", false, "Scan and report the tile count, then exit without writing any tiles")
 	flag.Parse()
 
 	if *workers < 1 {
@@ -42,19 +47,26 @@ func main() {
 
 	// The scale table (mercantile.Scale) is defined for z0..z23; beyond it the
 	// SCAMIN/SCAMAX filtering degrades, so clamp explicit flags into range.
-	const maxSupportedZoom = 23
-	clampZoom := func(name string, zp *int) {
-		switch {
-		case *zp < 0:
-			fmt.Printf("Note: -%s %d is below 0; clamped to 0.\n", name, *zp)
-			*zp = 0
-		case *zp > maxSupportedZoom:
-			fmt.Printf("Note: -%s %d exceeds the supported maximum z%d; clamped.\n", name, *zp, maxSupportedZoom)
-			*zp = maxSupportedZoom
+	applyClamp := func(name string, zp *int) {
+		v, note := clampZoomValue(name, *zp)
+		*zp = v
+		if note != "" {
+			fmt.Println(note)
 		}
 	}
-	clampZoom("minzoom", minzoom)
-	clampZoom("maxzoom", maxzoom)
+	applyClamp("minzoom", minzoom)
+	applyClamp("maxzoom", maxzoom)
+	if err := validateZoomRange(*minzoom, *maxzoom); err != nil {
+		log.Fatal(err)
+	}
+
+	// Fail fast if the output directory can't be created/written, before the
+	// (possibly long) scan and tiling. Skipped for a dry run, which writes nothing.
+	if !*dryRun {
+		if err := ensureWritableDir(*outputPath); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	// Honor explicit -minzoom/-maxzoom; otherwise the zoom range is derived per cell
 	// from its S-57 usage band (overview→berthing) in the pre-pass below.
@@ -84,27 +96,11 @@ func main() {
 
 	var bounds *m.Extrema = nil
 	if *boundsFlag != "" {
-		bounds = &m.Extrema{}
-		parts := strings.Split(*boundsFlag, ",")
-		if len(parts) != 4 {
-			log.Fatal("Invalid bounds")
+		b, err := parseBounds(*boundsFlag)
+		if err != nil {
+			log.Fatal(err)
 		}
-		for i, p := range parts {
-			if v, err := strconv.ParseFloat(p, 64); err == nil {
-				switch i {
-				case 0:
-					bounds.W = v
-				case 1:
-					bounds.N = v
-				case 2:
-					bounds.E = v
-				case 3:
-					bounds.S = v
-				}
-			} else {
-				log.Fatal("Invalid bounds")
-			}
-		}
+		bounds = &b
 	}
 
 	var tile *m.TileID = nil
@@ -123,6 +119,11 @@ func main() {
 			log.Fatal("Invalid at")
 		}
 	}
+
+	// Cancel cleanly on Ctrl-C / SIGTERM so an interrupted run stops feeding work
+	// instead of being killed mid-write.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	tiler := s57.NewS57Tiler(datasets)
 
@@ -181,9 +182,19 @@ func main() {
 	// can be very large, so surface the count before the (possibly long) tiling.
 	fmt.Printf("Generating %d tiles\n", grandTotal)
 
+	// A dry run reports the plan (zoom ranges + tile count) and stops before writing,
+	// so a wrong dataset/zoom is caught without committing to a multi-hour run.
+	if *dryRun {
+		fmt.Println("Dry run: no tiles written.")
+		return
+	}
+
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()
 	for _, wu := range work {
+		if ctx.Err() != nil {
+			break
+		}
 		prog.setStage(fmt.Sprintf("%s, Zoom: %d", wu.file.Id, wu.z))
 
 		jobs := make(chan m.TileID, *workers*2)
@@ -204,13 +215,21 @@ func main() {
 			}()
 		}
 		for _, t := range wu.tiles {
-			jobs <- t
+			select {
+			case jobs <- t:
+			case <-ctx.Done():
+			}
 		}
 		close(jobs)
 		wg.Wait()
 		tiler.GenerateMetaData(*outputPath, wu.dataset, wu.file, wu.minzoom, wu.maxzoom)
 	}
 	prog.finish()
+
+	if ctx.Err() != nil {
+		fmt.Fprintln(os.Stderr, "Interrupted; output is incomplete.")
+		os.Exit(130)
+	}
 }
 
 // workUnit is the tile set for a single (dataset, file, zoom), materialized during

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -138,6 +138,7 @@ func main() {
 	for _, ds := range datasets {
 		for _, file := range ds.Files {
 			fminzoom, fmaxzoom := *minzoom, *maxzoom
+			var extents []m.Extrema
 			if tile == nil {
 				zr := dataset.CellZoomRange(file)
 				if !userSetZoom && bounds == nil {
@@ -149,20 +150,20 @@ func main() {
 					availMin: zr.Min,
 					availMax: zr.Max,
 				})
+				if bounds != nil {
+					extents = []m.Extrema{*bounds}
+				} else {
+					// The full-scan layer extents are the same for every zoom, so
+					// compute them once per file instead of reopening the cell per zoom.
+					extents = tiler.FileExtents(file)
+				}
 			}
 			for z := fminzoom; z <= fmaxzoom; z++ {
-				var tiles map[string]m.TileID
+				var ids []m.TileID
 				if tile != nil {
-					tiles = map[string]m.TileID{"tile": *tile}
-				} else if bounds != nil {
-					tiles = tiler.GetTilesForBounds(nil, *bounds, z)
+					ids = []m.TileID{*tile}
 				} else {
-					tiles = tiler.GetTiles(file, z)
-				}
-
-				ids := make([]m.TileID, 0, len(tiles))
-				for _, t := range tiles {
-					ids = append(ids, t)
+					ids = s57.TilesForExtents(extents, z)
 				}
 				work = append(work, workUnit{dataset: ds, file: file, z: z, tiles: ids, minzoom: fminzoom, maxzoom: fmaxzoom})
 				grandTotal += int64(len(ids))

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -128,6 +128,7 @@ func main() {
 	defer stop()
 
 	tiler := s57.NewS57Tiler(datasets)
+	defer tiler.Close() // release its SRS/transform handles on normal exit
 
 	// Pre-pass: per file, derive its zoom range and cache its layer extents (one
 	// full scan), then count the tiles for a single global total + ETA. The tile

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -40,6 +40,7 @@ func main() {
 	at := flag.String("at", "", "lon,lat")
 	workers := flag.Int("workers", runtime.NumCPU()-1, "Number of parallel tile workers") // keep one CPU available for system responsiveness
 	dryRun := flag.Bool("dry-run", false, "Scan and report the tile count, then exit without writing any tiles")
+	maxTiles := flag.Int("max-tiles", 0, "Abort before tiling if the run would exceed this many tiles (0 = no limit)")
 	flag.Parse()
 
 	if *workers < 1 {
@@ -128,46 +129,39 @@ func main() {
 
 	tiler := s57.NewS57Tiler(datasets)
 
-	// Pre-pass: compute the tile set for every (dataset, file, zoom) up front so
-	// progress can be reported against a single global total with an ETA. Tile IDs
-	// are tiny, so materializing them all is cheap.
+	// Pre-pass: per file, derive its zoom range and cache its layer extents (one
+	// full scan), then count the tiles for a single global total + ETA. The tile
+	// IDs themselves are NOT materialized — they are streamed per file during
+	// generation (recomputing them from the cached extents is cheap arithmetic), so
+	// a multi-million-tile run doesn't hold the whole set in memory.
 	fmt.Println("Scanning…")
-	var work []workUnit
+	var work []fileWork
 	var grandTotal int64
 	var reports []zoomReport
 	for _, ds := range datasets {
 		for _, file := range ds.Files {
-			fminzoom, fmaxzoom := *minzoom, *maxzoom
-			var extents []m.Extrema
+			fw := fileWork{dataset: ds, file: file, minzoom: *minzoom, maxzoom: *maxzoom, single: tile}
 			if tile == nil {
 				zr := dataset.CellZoomRange(file)
 				if !userSetZoom && bounds == nil {
-					fminzoom, fmaxzoom = zr.Min, zr.Max
+					fw.minzoom, fw.maxzoom = zr.Min, zr.Max
 				}
 				reports = append(reports, zoomReport{
-					convMin:  fminzoom,
-					convMax:  fmaxzoom,
+					convMin:  fw.minzoom,
+					convMax:  fw.maxzoom,
 					availMin: zr.Min,
 					availMax: zr.Max,
 				})
 				if bounds != nil {
-					extents = []m.Extrema{*bounds}
+					fw.extents = []m.Extrema{*bounds}
 				} else {
 					// The full-scan layer extents are the same for every zoom, so
 					// compute them once per file instead of reopening the cell per zoom.
-					extents = tiler.FileExtents(file)
+					fw.extents = tiler.FileExtents(file)
 				}
 			}
-			for z := fminzoom; z <= fmaxzoom; z++ {
-				var ids []m.TileID
-				if tile != nil {
-					ids = []m.TileID{*tile}
-				} else {
-					ids = s57.TilesForExtents(extents, z)
-				}
-				work = append(work, workUnit{dataset: ds, file: file, z: z, tiles: ids, minzoom: fminzoom, maxzoom: fmaxzoom})
-				grandTotal += int64(len(ids))
-			}
+			work = append(work, fw)
+			grandTotal += fw.tileCount()
 		}
 	}
 
@@ -191,6 +185,11 @@ func main() {
 		return
 	}
 
+	// Guardrail against an accidental enormous run (e.g. a wrong dataset or zoom).
+	if *maxTiles > 0 && grandTotal > int64(*maxTiles) {
+		log.Fatalf("would generate %d tiles, exceeding -max-tiles %d; raise the limit or cap the zoom with -maxzoom", grandTotal, *maxTiles)
+	}
+
 	// Track write failures across all workers. A transient error (e.g. disk full,
 	// EPERM) no longer aborts the whole multi-hour run via log.Fatal; instead we
 	// keep going, surface the first error, count the rest, and exit non-zero at the
@@ -206,12 +205,15 @@ func main() {
 
 	prog := newProgress(grandTotal, os.Stdout)
 	go prog.run()
-	for _, wu := range work {
+	for _, fw := range work {
 		if ctx.Err() != nil {
 			break
 		}
-		prog.setStage(fmt.Sprintf("%s, Zoom: %d", wu.file.Id, wu.z))
+		prog.setStage(fw.file.Id)
 
+		// One worker pool per file: each worker's tiler opens this cell's datasource
+		// once and reuses it across every tile and zoom of the file, instead of the
+		// old per-(file,zoom) pool that reopened the cell for every zoom level.
 		jobs := make(chan m.TileID, *workers*2)
 		var wg sync.WaitGroup
 		for w := 0; w < *workers; w++ {
@@ -223,24 +225,19 @@ func main() {
 				// instances cannot be shared across goroutines.
 				workerTiler := s57.NewS57Tiler(datasets)
 				defer workerTiler.Close()
-				for tile := range jobs {
-					if err := workerTiler.GenerateTile(*outputPath, wu.file, tile); err != nil {
-						recordFailure(fmt.Sprintf("tile %s z%d %d/%d", wu.file.Id, tile.Z, tile.X, tile.Y), err)
+				for t := range jobs {
+					if err := workerTiler.GenerateTile(*outputPath, fw.file, t); err != nil {
+						recordFailure(fmt.Sprintf("tile %s z%d %d/%d", fw.file.Id, t.Z, t.X, t.Y), err)
 					}
 					prog.inc()
 				}
 			}()
 		}
-		for _, t := range wu.tiles {
-			select {
-			case jobs <- t:
-			case <-ctx.Done():
-			}
-		}
+		fw.streamTiles(ctx, jobs)
 		close(jobs)
 		wg.Wait()
-		if err := tiler.GenerateMetaData(*outputPath, wu.dataset, wu.file, wu.minzoom, wu.maxzoom); err != nil {
-			recordFailure("metadata "+wu.file.Id, err)
+		if err := tiler.GenerateMetaData(*outputPath, fw.dataset, fw.file, fw.minzoom, fw.maxzoom); err != nil {
+			recordFailure("metadata "+fw.file.Id, err)
 		}
 	}
 	prog.finish()
@@ -255,13 +252,51 @@ func main() {
 	}
 }
 
-// workUnit is the tile set for a single (dataset, file, zoom), materialized during
-// the pre-pass so it can be both counted toward the global total and processed.
-type workUnit struct {
+// fileWork describes the tiling for one cell: its converting zoom range and the
+// cached layer extents the tiles are derived from. Tiles are streamed (recomputed
+// from the extents) rather than materialized, so the global total can be counted
+// without holding millions of TileIDs in memory.
+type fileWork struct {
 	dataset dataset.Dataset
 	file    dataset.File
-	z       int
-	tiles   []m.TileID
 	minzoom int
 	maxzoom int
+	extents []m.Extrema // file/bounds mode; nil in -at mode
+	single  *m.TileID   // -at mode: the one tile to generate
+}
+
+// tileCount returns how many tiles this file contributes to the run.
+func (fw fileWork) tileCount() int64 {
+	if fw.single != nil {
+		return 1
+	}
+	var n int64
+	for z := fw.minzoom; z <= fw.maxzoom; z++ {
+		n += int64(len(s57.TilesForExtents(fw.extents, z)))
+	}
+	return n
+}
+
+// streamTiles feeds this file's tiles (all zooms) into jobs, stopping early if the
+// context is cancelled. Recomputed from the cached extents — no full set is held.
+func (fw fileWork) streamTiles(ctx context.Context, jobs chan<- m.TileID) {
+	send := func(t m.TileID) bool {
+		select {
+		case jobs <- t:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	if fw.single != nil {
+		send(*fw.single)
+		return
+	}
+	for z := fw.minzoom; z <= fw.maxzoom; z++ {
+		for _, t := range s57.TilesForExtents(fw.extents, z) {
+			if !send(t) {
+				return
+			}
+		}
+	}
 }

--- a/s57/bench_perf_test.go
+++ b/s57/bench_perf_test.go
@@ -1,0 +1,58 @@
+package s57
+
+import (
+	"testing"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// These benchmarks track the native-zoom pre-pass + generation hot path that the
+// performance work targets: the per-file extent scan (done once per file), the
+// per-zoom tile arithmetic (done while streaming), and generating one cell across
+// several zooms with a single tiler (the per-file worker-pool model, where the
+// cell's datasource is opened once and reused across zooms).
+
+// BenchmarkFileExtents measures the one-per-file full-scan extent computation.
+func BenchmarkFileExtents(b *testing.B) {
+	datasets, file := benchFixture(b)
+	tiler := NewS57Tiler(datasets)
+	defer tiler.Close()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tiler.FileExtents(*file)
+	}
+}
+
+// BenchmarkTilesForExtents measures the per-zoom tile-set arithmetic that runs
+// during streaming (and twice more for the up-front count) — it must stay cheap,
+// since the pre-pass no longer pays a datasource reopen per zoom.
+func BenchmarkTilesForExtents(b *testing.B) {
+	datasets, file := benchFixture(b)
+	tiler := NewS57Tiler(datasets)
+	defer tiler.Close()
+	extents := tiler.FileExtents(*file)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = TilesForExtents(extents, 12)
+	}
+}
+
+// BenchmarkGenerateTileMultiZoom mirrors the per-file pool: one tiler generates a
+// cell's centre tile across several zooms, reusing the cached datasource across
+// all of them rather than reopening per zoom.
+func BenchmarkGenerateTileMultiZoom(b *testing.B) {
+	datasets, file := benchFixture(b)
+	tiler := NewS57Tiler(datasets)
+	defer tiler.Close()
+	tiles := []m.TileID{denseTile(b, file, 12), denseTile(b, file, 13), denseTile(b, file, 14)}
+	tmp := b.TempDir()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, t := range tiles {
+			tiler.GenerateTile(tmp, *file, t)
+		}
+	}
+}

--- a/s57/dataset/dataset.go
+++ b/s57/dataset/dataset.go
@@ -35,6 +35,11 @@ type File struct {
 	Path   string
 	Title  string
 	Layers map[string]Layer
+	// Intu (DSID_INTU usage band) and Cscl (DSPM_CSCL compilation scale) are read
+	// once from the cell's DSID record at discovery, so the zoom derivation
+	// (UsageBand/CellZoomRange) doesn't reopen the datasource per cell.
+	Intu int
+	Cscl int
 }
 
 type Dataset struct {
@@ -185,12 +190,18 @@ func GetS57Datasets(path string) ([]Dataset, error) {
 					// on large catalogs).
 					datasource := gdal.OpenDataSource(filePath, 0)
 					layers := getLayers(datasource)
+					intu, cscl, hasDSID := readDSID(datasource)
 					datasource.Destroy()
+					if !hasDSID {
+						fmt.Fprintf(os.Stderr, "warning: %s has no DSID record; using the default zoom range\n", cellID)
+					}
 					dataset.Files = append(dataset.Files, File{
 						Id:     cellID,
 						Path:   filePath,
 						Title:  title,
 						Layers: layers,
+						Intu:   intu,
+						Cscl:   cscl,
 					})
 				}
 				datasets = append(datasets, dataset)

--- a/s57/dataset/usageband.go
+++ b/s57/dataset/usageband.go
@@ -5,18 +5,19 @@ import (
 	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
-// dsidInfo reads the cell's DSID record once and returns the usage band
-// (DSID_INTU) and the compilation-scale denominator (DSPM_CSCL); each is 0 when
-// absent. The DSID layer is geometry-less and therefore excluded from
-// File.Layers, so we open the datasource and scan layers by index.
-func dsidInfo(file File) (intu int, cscl int) {
-	ds := gdal.OpenDataSource(file.Path, 0)
-	defer ds.Destroy()
+// readDSID reads the cell's DSID record from an already-open datasource and
+// returns the usage band (DSID_INTU), the compilation-scale denominator
+// (DSPM_CSCL), and whether a DSID record was found. The values are cached on the
+// File at discovery so the zoom derivation never has to reopen the cell. The DSID
+// layer is geometry-less and therefore excluded from File.Layers, so we scan
+// layers by index.
+func readDSID(ds gdal.DataSource) (intu int, cscl int, found bool) {
 	for i := 0; i < ds.LayerCount(); i++ {
 		layer := ds.LayerByIndex(i)
 		if layer.Name() != "DSID" {
 			continue
 		}
+		found = true
 		layer.ResetReading()
 		feat := layer.NextFeature()
 		if feat != nil {
@@ -30,7 +31,7 @@ func dsidInfo(file File) (intu int, cscl int) {
 		}
 		break
 	}
-	return intu, cscl
+	return intu, cscl, found
 }
 
 // resolveBand maps a cell's DSID_INTU and id to a standard S-57 usage band
@@ -52,8 +53,7 @@ func resolveBand(intu int, id string) int {
 // the authoritative DSID_INTU value from the cell's DSID record, falls back to
 // the navigational-purpose digit in the cell name, and returns 0 when unknown.
 func UsageBand(file File) int {
-	intu, _ := dsidInfo(file)
-	return resolveBand(intu, file.Id)
+	return resolveBand(file.Intu, file.Id)
 }
 
 // BandZoom maps a usage band to a default web-map zoom range. The values are a
@@ -87,16 +87,17 @@ type ZoomRange struct {
 	Min, Max int
 }
 
-// CellZoomRange returns a cell's default zoom range from a single DSID read. The
-// minimum comes from the usage band (overview charts start coarse, harbour
-// charts start fine); for an inland/unknown band it is a fixed floor. The
-// maximum is the cell's native zoom — the finest level matching its compilation
-// scale (DSPM_CSCL) — and is never capped below the band default. So a 1:2000
-// inland chart tiles up to z19 and a 1:20000 approach chart up to z16.
+// CellZoomRange returns a cell's default zoom range from its cached DSID values
+// (read once at discovery). The minimum comes from the usage band (overview
+// charts start coarse, harbour charts start fine); for an inland/unknown band it
+// is a fixed floor. The maximum is the cell's native zoom — the finest level
+// matching its compilation scale (DSPM_CSCL) — and is never capped below the band
+// default. So a 1:2000 inland chart tiles up to z19 and a 1:20000 approach chart
+// up to z16.
 func CellZoomRange(file File) ZoomRange {
 	const inlandFloor = 12 // coarse floor for inland/large-scale cells (no usage band)
-	intu, cscl := dsidInfo(file)
-	band := resolveBand(intu, file.Id)
+	cscl := file.Cscl
+	band := resolveBand(file.Intu, file.Id)
 
 	var minZ, maxZ int
 	switch {

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -512,31 +512,42 @@ func (s *s57Tiler) GetFeatures(layer gdal.Layer, tile m.TileID, tileBounds m.Ext
 	return features
 }
 
-func (s *s57Tiler) GetTilesForBounds(tiles map[string]m.TileID, bounds m.Extrema, zoomLevel int) map[string]m.TileID {
-	if tiles == nil {
-		tiles = make(map[string]m.TileID)
-	}
-	ulTile := m.Tile(bounds.W, bounds.N, zoomLevel)
-	lrTile := m.Tile(bounds.E, bounds.S, zoomLevel)
-	for col := ulTile.X; col <= lrTile.X; col++ {
-		for row := ulTile.Y; row <= lrTile.Y; row++ {
-			key := fmt.Sprintf("%d,%d,%d", col, row, zoomLevel)
-			tile := m.TileID{X: col, Y: row, Z: uint64(zoomLevel)}
-			tiles[key] = tile
-		}
-	}
-	return tiles
-}
-
-func (s *s57Tiler) GetTiles(file dataset.File, zoomLevel int) map[string]m.TileID {
-	tiles := make(map[string]m.TileID)
+// FileExtents opens the cell once and returns each layer's extent (the expensive
+// full-scan Extent(true)). The pre-pass derives every zoom's tile set from these
+// cached extents via TilesForExtents, instead of reopening and re-scanning the
+// cell once per zoom.
+func (s *s57Tiler) FileExtents(file dataset.File) []m.Extrema {
 	datasource := gdal.OpenDataSource(file.Path, 0)
 	defer datasource.Destroy()
+	var extents []m.Extrema
 	for i := 0; i < datasource.LayerCount(); i++ {
 		l := datasource.LayerByIndex(i)
 		ext, err := l.Extent(true)
 		if err == nil {
-			tiles = s.GetTilesForBounds(tiles, m.Extrema{W: ext.MinX(), N: ext.MaxY(), E: ext.MaxX(), S: ext.MinY()}, zoomLevel)
+			extents = append(extents, m.Extrema{W: ext.MinX(), N: ext.MaxY(), E: ext.MaxX(), S: ext.MinY()})
+		}
+	}
+	return extents
+}
+
+// TilesForExtents returns the deduplicated tiles covering the given extents at
+// zoomLevel, in deterministic (column-major) order. Dedup is keyed by TileID
+// directly, avoiding a formatted string allocation per tile in a loop that can run
+// into the millions.
+func TilesForExtents(extents []m.Extrema, zoomLevel int) []m.TileID {
+	seen := make(map[m.TileID]struct{})
+	tiles := make([]m.TileID, 0)
+	for _, b := range extents {
+		ulTile := m.Tile(b.W, b.N, zoomLevel)
+		lrTile := m.Tile(b.E, b.S, zoomLevel)
+		for col := ulTile.X; col <= lrTile.X; col++ {
+			for row := ulTile.Y; row <= lrTile.Y; row++ {
+				t := m.TileID{X: col, Y: row, Z: uint64(zoomLevel)}
+				if _, ok := seen[t]; !ok {
+					seen[t] = struct{}{}
+					tiles = append(tiles, t)
+				}
+			}
 		}
 	}
 	return tiles

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -207,8 +207,10 @@ func IsClockWise(geom *gdal.Geometry) bool {
 }
 
 func (s *s57Tiler) toMvtLinestringGeometry(geometry *gdal.Geometry, tileBounds m.Extrema, ccw bool) []uint32 {
-	mvtGeometry := make([]uint32, 0)
 	count := geometry.PointCount()
+	// Each vertex emits 2 ints, plus the moveto/lineto commands (and +1 of headroom
+	// for the polygon close-path the caller may append) — pre-size to avoid regrowth.
+	mvtGeometry := make([]uint32, 0, 2*count+4)
 
 	if count > 1 {
 		index := 0
@@ -254,8 +256,8 @@ func (s *s57Tiler) toMvtPolygonGeometry(geometry *gdal.Geometry, tileBounds m.Ex
 }
 
 func (s *s57Tiler) toMvtPointGeometry(geometry *gdal.Geometry, tileBounds m.Extrema) []uint32 {
-	mvtGeometry := make([]uint32, 0)
 	count := geometry.PointCount()
+	mvtGeometry := make([]uint32, 0, 2*count+1)
 	mvtGeometry = append(mvtGeometry, getCommand(1, count))
 	for i := 0; i < count; i++ {
 		x, y, _ := geometry.Point(i)
@@ -276,7 +278,9 @@ func (s *s57Tiler) toMvtGeometry(featureType vectortile.Tile_GeomType, geometry 
 	s.lasty = 0
 	mvtGeometry := make([]uint32, 0)
 
-	tolerance := TILE_DIMENSION_AT_0 / math.Pow(2, float64(tile.Z)) / 256 * SIMPLIFICATION_FACTOR
+	// 2^Z is exact for the supported zooms (Z<=23), so a bit shift avoids math.Pow
+	// per feature while producing the identical tolerance.
+	tolerance := TILE_DIMENSION_AT_0 / float64(uint64(1)<<tile.Z) / 256 * SIMPLIFICATION_FACTOR
 
 	simplifiedGeometry := geometry.SimplifyPreservingTopology(tolerance)
 	defer simplifiedGeometry.Destroy()

--- a/s57/tiles_test.go
+++ b/s57/tiles_test.go
@@ -26,14 +26,10 @@ func TestTilesForExtents(t *testing.T) {
 		t.Errorf("no extents = %d tiles, want 0", len(none))
 	}
 
-	// At z1 a single point lands on exactly one tile, in range.
-	one := TilesForExtents([]m.Extrema{{W: 0.1, N: 0.1, E: 0.2, S: 0.0}}, 1)
-	if len(one) != 1 {
-		t.Errorf("tiny extent at z1 = %d tiles, want 1", len(one))
-	}
-	for _, tile := range one {
-		if tile.Z != 1 || tile.X < 0 || tile.X > 1 || tile.Y < 0 || tile.Y > 1 {
-			t.Errorf("z1 tile %+v out of [0,2) grid", tile)
-		}
+	// A small box well inside the NW quadrant lands on exactly the one z1 tile {0,0,1}
+	// (z1 splits the world into 2x2: col 0 = west of 0°, row 0 = north of the equator).
+	one := TilesForExtents([]m.Extrema{{W: -100, N: 40, E: -99, S: 39}}, 1)
+	if len(one) != 1 || one[0] != (m.TileID{X: 0, Y: 0, Z: 1}) {
+		t.Errorf("NW box at z1 = %+v, want [{0 0 1}]", one)
 	}
 }

--- a/s57/tiles_test.go
+++ b/s57/tiles_test.go
@@ -1,0 +1,39 @@
+package s57
+
+import (
+	"testing"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// TestTilesForExtents checks the dedup + tiling arithmetic that replaced the old
+// string-keyed GetTiles/GetTilesForBounds: overlapping extents must not produce
+// duplicate tiles, and an empty input yields nothing.
+func TestTilesForExtents(t *testing.T) {
+	world := m.Extrema{W: -179, N: 85, E: 179, S: -85}
+
+	got := TilesForExtents([]m.Extrema{world}, 0)
+	if len(got) != 1 || got[0] != (m.TileID{X: 0, Y: 0, Z: 0}) {
+		t.Fatalf("z0 single extent = %+v, want [{0 0 0}]", got)
+	}
+
+	// The same extent twice must dedup to the identical single tile.
+	if dup := TilesForExtents([]m.Extrema{world, world}, 0); len(dup) != 1 {
+		t.Errorf("duplicate extents = %d tiles, want 1 (deduped)", len(dup))
+	}
+
+	if none := TilesForExtents(nil, 5); len(none) != 0 {
+		t.Errorf("no extents = %d tiles, want 0", len(none))
+	}
+
+	// At z1 a single point lands on exactly one tile, in range.
+	one := TilesForExtents([]m.Extrema{{W: 0.1, N: 0.1, E: 0.2, S: 0.0}}, 1)
+	if len(one) != 1 {
+		t.Errorf("tiny extent at z1 = %d tiles, want 1", len(one))
+	}
+	for _, tile := range one {
+		if tile.Z != 1 || tile.X < 0 || tile.X > 1 || tile.Y < 0 || tile.Y > 1 {
+			t.Errorf("z1 tile %+v out of [0,2) grid", tile)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Native-zoom runs over large-scale charts are big and long (the Waddenzee set = ~3.74M tiles). The tiling pipeline had several costs that multiplied with the number of cells and zoom levels:

- **Per-zoom datasource reopen + full rescan:** `GetTiles` reopened the cell and ran the expensive `Extent(true)` full scan *once per zoom level*.
- **Per-cell DSID reopen:** `CellZoomRange` reopened each cell just to read one DSID record in the pre-pass.
- **Whole tile set materialized in memory:** the pre-pass built every `TileID` for every (file, zoom) up front — millions of structs resident at once (OOM risk on pathological inputs).
- **Per-(file,zoom) worker pool:** a fresh pool of N tilers was created/destroyed for every zoom level, so each cell's datasource was reopened for every zoom.
- **Per-tile allocations:** `math.Pow` per feature, zero-capacity geometry slices, a `fmt.Sprintf` string key per tile in the dedup map.

## What changed

1. **Cache DSID at discovery** — read `DSID_INTU`/`DSPM_CSCL` once when the cell is opened to enumerate layers; store on `dataset.File`; `UsageBand`/`CellZoomRange` read the cached values. Warn when a cell has no DSID record.
2. **Trim encoder allocations** — `math.Pow(2,Z)` → exact bit shift; pre-size the linestring/point geometry builders. Byte-identical output.
3. **`FileExtents` + `TilesForExtents`** — compute each cell's layer extents once (one full scan per file) and derive every zoom's tile set from them, deduped by `TileID` instead of a formatted string key. Replaces `GetTiles`/`GetTilesForBounds`.
4. **Per-file streaming worker pool + `-max-tiles`** — one pool per file (each worker opens the cell's datasource once and reuses it across all the file's tiles/zooms); tiles are *streamed* from the cached extents rather than materialized; `-max-tiles` aborts an accidental oversized run before writing. Metadata is written once per file.
5. **Benchmarks** for the pre-pass scan, per-zoom arithmetic, and multi-zoom generation.
6. **Close the shared tiler on exit** (review-surfaced; finishes the PR3 leak fix for the CLI's main tiler).

## Output equivalence (this is a refactor — tiles must not change)

Verified, not assumed:
- `TestDenseTileFingerprint` is **identical** on `master` and this branch (`b711f2847b6dbf7c`).
- End-to-end decoded-content diff of both binaries over the `enc/` fixture: **0 mismatches** across 644 tiles (`-minzoom 9 -maxzoom 12`) and 33 tiles (bounds mode).
- Native-zoom dry-run reports the **same grand total (3,741,201 tiles)** on both — confirming the DSID-cache + extent pipeline reproduce the old `dsidInfo`/`GetTiles` results exactly.

## Measured impact (master → this branch)

Local A/B (Apple Silicon, 16 logical cores, GDAL 3.13; 22-cell fixture; output verified identical, 1761 == 1761 tiles). Wall-clock, 3 runs each — indicative, not benchstat-rigorous:

| Phase | Workload | master | this branch | Δ |
|-------|----------|-------:|------------:|--:|
| Pre-pass (dry-run) | 22 cells × 8 zooms (z9–16) | ~1.78 s | ~0.43 s | ~4.1× |
| End-to-end generate | z9–13, 1761 tiles | ~34.3 s | ~19.5 s | ~1.75× |

- Pre-pass: master re-ran the full-scan `Extent(true)` once per zoom (8×) and materialized every tile ID; this branch scans once per cell and streams. The gap widens with the zoom count.
- Generation: master ran at ~733% CPU, this branch at ~1345% — total user-CPU is unchanged (~same tiling work), so the speedup is parallelism (the per-file pool keeps workers saturated across a file's zooms instead of churning a pool + reopening the cell per zoom), not less computation.
- The streaming/memory win (no full TileID materialization) is real but unquantified here: the native z19 / 3.74M-tile case can't be fairly A/B'd because master would materialize all of them and run very slowly / risk OOM — which is the scalability bug this branch fixes.

## Tests / benchmarks

- `s57/tiles_test.go` (new): `TestTilesForExtents` (TileID dedup + tiling arithmetic), written test-first.
- `cmd/s57-tiler/filework_test.go` (new): `tileCount` and `streamTiles` cancel-safety (returns promptly on a cancelled context, doesn't block a full channel).
- `s57/bench_perf_test.go` (new): `FileExtents` (~9.8 ms), `TilesForExtents` (~42 µs), multi-zoom generate — the µs-vs-ms gap is the win: the full scan now runs once per file, not once per zoom.
- Existing `usageband` tests now exercise the cached-DSID path.

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` green ·`go test -race ./s57/ ./cmd/...` clean (incl. `-count=3`).