### PR TITLE
Merge 3rd - Chore: robustness, tests, and CI hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,17 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Verify the test fixture is present
         # The s57 tests t.Skip when the bundled enc/ fixture is missing, which would
         # leave this job green without actually exercising the code. Fail instead, so a
         # passing check guarantees the suite ran.
         run: test -f enc/CATALOG.031 || { echo "enc/ fixture missing — s57 tests would skip"; exit 1; }
 
-      - name: Test
-        run: go test ./... -count=1
+      - name: Test (race detector)
+        # -race exercises the worker-pool concurrency model (per-worker tilers, the
+        # progress reporter, failure tracking). The deterministic-bytes and fingerprint
+        # tests run here too, gating tile-output regressions.
+        run: go test ./... -race -count=1

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -223,7 +223,8 @@ func main() {
 				workerTiler := s57.NewS57Tiler(datasets)
 				defer workerTiler.Close()
 				for tile := range jobs {
-					if err := workerTiler.GenerateTile(*outputPath, wu.file, tile); err != nil {
+					err := runTile(func() error { return workerTiler.GenerateTile(*outputPath, wu.file, tile) })
+					if err != nil {
 						recordFailure(fmt.Sprintf("tile %s z%d %d/%d", wu.file.Id, tile.Z, tile.X, tile.Y), err)
 					}
 					prog.inc()
@@ -252,6 +253,18 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Completed with %d write failure(s); output is incomplete.\n", n)
 		os.Exit(1)
 	}
+}
+
+// runTile runs do, converting a panic (e.g. from a pathological geometry in the
+// GDAL pipeline) into an error so a single bad tile is recorded as a failure and
+// the run continues, rather than crashing the whole multi-hour job.
+func runTile(do func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return do()
 }
 
 // workUnit is the tile set for a single (dataset, file, zoom), materialized during

--- a/cmd/s57-tiler/main.go
+++ b/cmd/s57-tiler/main.go
@@ -28,8 +28,9 @@ func main() {
 	}
 	driver.Register()
 
-	// GDAL S-57 reader options (incl. SOUNDG handling) are configured in the dataset
-	// package's init, so they apply consistently to the CLI and tests.
+	// Configure the GDAL S-57 reader options (incl. SOUNDG handling) before any
+	// datasource is opened.
+	dataset.ConfigureGDAL()
 
 	outputPath := flag.String("out", "./static/charts", "Output directory for vector tiles")
 	inputPath := flag.String("in", "./charts", "Input path S-57 ENC's")

--- a/cmd/s57-tiler/runtile_test.go
+++ b/cmd/s57-tiler/runtile_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRunTile(t *testing.T) {
+	if err := runTile(func() error { panic("boom") }); err == nil {
+		t.Error("runTile should convert a panic into an error, got nil")
+	}
+	sentinel := errors.New("write failed")
+	if err := runTile(func() error { return sentinel }); err != sentinel {
+		t.Errorf("runTile should pass the error through, got %v", err)
+	}
+	if err := runTile(func() error { return nil }); err != nil {
+		t.Errorf("runTile(success) = %v, want nil", err)
+	}
+}

--- a/s57/dataset/dataset.go
+++ b/s57/dataset/dataset.go
@@ -13,14 +13,16 @@ import (
 	m "github.com/wdantuma/s57-tiler/s57/mercantile"
 )
 
-// init configures the GDAL S-57 reader. These are process-global GDAL options and
-// must be set before any datasource is opened, so they live here (imported by both
-// the CLI and the tests) rather than in main.
+// ConfigureGDAL sets the process-global GDAL S-57 reader options. It must be called
+// once before any datasource is opened — the CLI calls it at startup, and test
+// packages call it from TestMain. It replaces an init() so that merely importing
+// this package no longer mutates the process environment as a side effect (which
+// was a test-ordering / library-purity hazard).
 //
 //   - SPLIT_MULTIPOINT/ADD_SOUNDG_DEPTH: emit each depth sounding as its own 3D point
 //     feature with a real DEPTH attribute (otherwise SOUNDG is a multipoint whose depth
 //     lives only in the geometry Z and is lost during tiling).
-func init() {
+func ConfigureGDAL() {
 	os.Setenv("OGR_S57_OPTIONS", "SPLIT_MULTIPOINT=ON,ADD_SOUNDG_DEPTH=ON")
 	os.Setenv("OGR_GEOMETRY_ACCEPT_UNCLOSED_RING", "NO")
 }

--- a/s57/dataset/main_test.go
+++ b/s57/dataset/main_test.go
@@ -1,0 +1,13 @@
+package dataset
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain configures the GDAL reader options before any test opens a datasource,
+// now that ConfigureGDAL replaces the package init().
+func TestMain(m *testing.M) {
+	ConfigureGDAL()
+	os.Exit(m.Run())
+}

--- a/s57/determinism_test.go
+++ b/s57/determinism_test.go
@@ -1,0 +1,67 @@
+package s57
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// TestGenerateTileDeterministicBytes guards that a tile encodes to identical bytes
+// on every run. Layers are now emitted in sorted order, so map-iteration
+// randomness can't perturb the .pbf — a regression that reintroduces nondeterminism
+// (or otherwise changes the encoding) fails here. Fixture-gated.
+func TestGenerateTileDeterministicBytes(t *testing.T) {
+	if _, err := os.Stat(sampleENC + "/CATALOG.031"); err != nil {
+		t.Skipf("sample ENC not present at %s: %v", sampleENC, err)
+	}
+	datasets, err := dataset.GetS57Datasets(sampleENC)
+	if err != nil {
+		t.Fatalf("GetS57Datasets: %v", err)
+	}
+	var file *dataset.File
+	for di := range datasets {
+		for fi := range datasets[di].Files {
+			if datasets[di].Files[fi].Id == "US4WA1JJ" {
+				file = &datasets[di].Files[fi]
+			}
+		}
+	}
+	if file == nil {
+		t.Skip("US4WA1JJ not found in sample ENC")
+	}
+	mcovr, ok := file.Layers["M_COVR"]
+	if !ok {
+		t.Skip("fixture has no M_COVR layer")
+	}
+	lon := (mcovr.Bounds.MinX() + mcovr.Bounds.MaxX()) / 2
+	lat := (mcovr.Bounds.MinY() + mcovr.Bounds.MaxY()) / 2
+	tile := m.Tile(lon, lat, 14)
+
+	read := func() []byte {
+		tiler := NewS57Tiler(datasets)
+		defer tiler.Close()
+		tmp := t.TempDir()
+		if err := tiler.GenerateTile(tmp, *file, tile); err != nil {
+			t.Fatalf("GenerateTile: %v", err)
+		}
+		pbf := filepath.Join(tmp, file.Id, strconv.Itoa(int(tile.Z)),
+			strconv.Itoa(int(tile.X)), strconv.Itoa(int(tile.Y))+".pbf")
+		b, err := os.ReadFile(pbf)
+		if err != nil {
+			t.Fatalf("dense tile not written: %v", err)
+		}
+		return b
+	}
+
+	first := read()
+	for i := 0; i < 4; i++ {
+		if got := read(); !bytes.Equal(got, first) {
+			t.Fatalf("tile bytes not deterministic: run %d (%d bytes) != run 0 (%d bytes)", i+1, len(got), len(first))
+		}
+	}
+}

--- a/s57/filter_test.go
+++ b/s57/filter_test.go
@@ -1,0 +1,31 @@
+package s57
+
+import "testing"
+
+// scaleVisible is the SCAMIN/SCAMAX visibility predicate extracted from
+// includeFeatureInTile. SCAMIN/SCAMAX are 0 when unset; scale is the tile's scale
+// denominator. A feature is hidden when it is below its minimum scale (scamin <
+// scale) or above its maximum scale (scamax > scale).
+func TestScaleVisible(t *testing.T) {
+	cases := []struct {
+		name           string
+		scamin, scamax float64
+		scale          int32
+		want           bool
+	}{
+		{"both unset", 0, 0, 70000, true},
+		{"scamin hides when zoomed out past it", 50000, 0, 70000, false},
+		{"scamin allows when within range", 50000, 0, 35000, true},
+		{"scamin boundary (equal) shows", 70000, 0, 70000, true},
+		{"scamax hides when zoomed in past it", 0, 100000, 70000, false},
+		{"scamax allows when within range", 0, 100000, 150000, true},
+		{"scamax boundary (equal) shows", 0, 70000, 70000, true},
+		{"scamin takes effect even with scamax set", 50000, 200000, 100000, false},
+		{"within both bounds", 50000, 200000, 70000, true},
+	}
+	for _, c := range cases {
+		if got := scaleVisible(c.scamin, c.scamax, c.scale); got != c.want {
+			t.Errorf("%s: scaleVisible(%g,%g,%d) = %v, want %v", c.name, c.scamin, c.scamax, c.scale, got, c.want)
+		}
+	}
+}

--- a/s57/filter_test.go
+++ b/s57/filter_test.go
@@ -21,7 +21,7 @@ func TestScaleVisible(t *testing.T) {
 		{"scamax allows when within range", 0, 100000, 150000, true},
 		{"scamax boundary (equal) shows", 0, 70000, 70000, true},
 		{"scamin takes effect even with scamax set", 50000, 200000, 100000, false},
-		{"within both bounds", 50000, 200000, 70000, true},
+		{"within both bounds (scamin>=scale>=scamax)", 200000, 50000, 70000, true},
 	}
 	for _, c := range cases {
 		if got := scaleVisible(c.scamin, c.scamax, c.scale); got != c.want {

--- a/s57/main_test.go
+++ b/s57/main_test.go
@@ -1,0 +1,15 @@
+package s57
+
+import (
+	"os"
+	"testing"
+
+	"github.com/wdantuma/s57-tiler/s57/dataset"
+)
+
+// TestMain configures the GDAL reader options before any test opens a datasource
+// (e.g. SOUNDG splitting), now that dataset.ConfigureGDAL replaces the package init().
+func TestMain(m *testing.M) {
+	dataset.ConfigureGDAL()
+	os.Exit(m.Run())
+}

--- a/s57/projection_test.go
+++ b/s57/projection_test.go
@@ -1,0 +1,48 @@
+package s57
+
+import (
+	"math"
+	"testing"
+
+	m "github.com/wdantuma/s57-tiler/s57/mercantile"
+)
+
+// TestTo3857Origin checks the geographic->Web-Mercator transform at the
+// unambiguous origin (lon=0, lat=0 maps to 0,0).
+func TestTo3857Origin(t *testing.T) {
+	tiler := NewS57Tiler(nil)
+	defer tiler.Close()
+	x, y := tiler.to3857(0, 0)
+	if math.Abs(x) > 1 || math.Abs(y) > 1 {
+		t.Errorf("to3857(0,0) = (%g,%g), want ~(0,0)", x, y)
+	}
+}
+
+// TestToTileCoordinateMapsCorners is the end-to-end guard for the projection
+// pipeline (to3857 + setProjection caching + the tile-unit scaling): a tile's
+// upper-left corner must map to ~(0,0) and its lower-right to ~(TILE_EXTENT,
+// TILE_EXTENT). Iterating distinct tiles also exercises setProjection's cache
+// invalidation when the bounds change. A regression here renders features at the
+// wrong position with no error signal.
+func TestToTileCoordinateMapsCorners(t *testing.T) {
+	tiler := NewS57Tiler(nil)
+	defer tiler.Close()
+	for _, tile := range []m.TileID{{X: 2614, Y: 5664, Z: 14}, {X: 0, Y: 0, Z: 1}, {X: 8, Y: 5, Z: 4}} {
+		b := m.Bounds(tile)
+		ulx, uly, _ := tiler.toTileCoordinate(b, b.W, b.N, 0)
+		if abs32(ulx) > 1 || abs32(uly) > 1 {
+			t.Errorf("tile %+v UL corner = (%d,%d), want ~(0,0)", tile, ulx, uly)
+		}
+		lrx, lry, _ := tiler.toTileCoordinate(b, b.E, b.S, 0)
+		if abs32(lrx-TILE_EXTENT) > 1 || abs32(lry-TILE_EXTENT) > 1 {
+			t.Errorf("tile %+v LR corner = (%d,%d), want ~(%d,%d)", tile, lrx, lry, TILE_EXTENT, TILE_EXTENT)
+		}
+	}
+}
+
+func abs32(v int32) int32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -602,7 +603,16 @@ func (s *s57Tiler) GenerateTile(outPath string, file dataset.File, tile m.TileID
 	// generates (released by Close()), instead of reopening the S-57 cell each time.
 	datasource := s.datasource(file.Path)
 
-	for layerName, layer := range file.Layers {
+	// Iterate layers in a stable order so the encoded .pbf is byte-deterministic.
+	// Go map iteration over file.Layers is randomized, which otherwise makes the
+	// tile bytes vary run-to-run even when the decoded content is identical.
+	layerNames := make([]string, 0, len(file.Layers))
+	for layerName := range file.Layers {
+		layerNames = append(layerNames, layerName)
+	}
+	sort.Strings(layerNames)
+	for _, layerName := range layerNames {
+		layer := file.Layers[layerName]
 		ln := layerName
 		var version uint32 = 2
 		var extent uint32 = TILE_EXTENT

--- a/s57/s57tiler.go
+++ b/s57/s57tiler.go
@@ -456,23 +456,29 @@ func (s *s57Tiler) toMvtFeature(feature *gdal.Feature, tile m.TileID, tileBounds
 }
 
 func includeFeatureInTile(feature gdal.Feature, tile m.TileID) bool {
-
-	scale := m.Scale(tile)
-	scaminIndex := feature.FieldIndex("SCAMIN")
-	if scaminIndex >= 0 {
-		scamin := feature.FieldAsFloat64(scaminIndex)
-		if scamin != 0 && scamin < float64(scale) {
-			return false
-		}
+	var scamin, scamax float64
+	if idx := feature.FieldIndex("SCAMIN"); idx >= 0 {
+		scamin = feature.FieldAsFloat64(idx)
 	}
-	scamaxIndex := feature.FieldIndex("SCAMAX")
-	if scamaxIndex >= 0 {
-		scamax := feature.FieldAsFloat64(scamaxIndex)
-		if scamax != 0 && scamax > float64(scale) {
-			return false
-		}
+	if idx := feature.FieldIndex("SCAMAX"); idx >= 0 {
+		scamax = feature.FieldAsFloat64(idx)
 	}
+	return scaleVisible(scamin, scamax, m.Scale(tile))
+}
 
+// scaleVisible reports whether a feature with the given SCAMIN/SCAMAX (0 = unset)
+// is shown at the tile's scale denominator. The feature is hidden when displayed
+// below its minimum scale (scamin < scale) or above its maximum scale
+// (scamax > scale). Split out as a pure function so the boundary logic — whose
+// failure mode is silently hiding/showing features at the wrong zoom — is unit
+// tested without a GDAL feature.
+func scaleVisible(scamin, scamax float64, scale int32) bool {
+	if scamin != 0 && scamin < float64(scale) {
+		return false
+	}
+	if scamax != 0 && scamax > float64(scale) {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
## Why

The logic that decides *whether* and *where* features render had no hermetic coverage, the worker pool crashed the whole run on a single panicking tile, tile bytes were nondeterministic, the GDAL config was applied as an import side effect, and CI ran neither `vet` nor the race detector.

## What changed

- **`scaleVisible` predicate** — extracted the SCAMIN/SCAMAX visibility decision out of `includeFeatureInTile` into a pure function and unit-tested its boundaries (the failure mode is silently hiding/showing features at the wrong zoom). Behavior unchanged.
- **Coordinate-pipeline tests** — direct tests for `to3857` (origin) and `toTileCoordinate` (tile corners map to `(0,0)`/`(4096,4096)`, exercising `setProjection` cache invalidation). A regression here mis-positions features with no error signal.
- **Deterministic tile bytes** — `GenerateTile` now emits MVT layers in sorted order, so the `.pbf` is byte-reproducible (Go map iteration over `file.Layers` previously randomized it). Decoded content and the order-independent fingerprint are unchanged; `TestGenerateTileDeterministicBytes` regenerates a tile 5× and asserts identical bytes.
- **`recover` in the worker pool** — each `GenerateTile` runs through `runTile`, which converts a panic (e.g. a pathological geometry) into a recorded failure so the run continues and still exits non-zero, instead of crashing the whole job.
- **`ConfigureGDAL()` replaces `dataset.init()`** — importing the package no longer mutates the process environment; `main()` calls it at startup and the `s57`/`s57/dataset` test packages call it from `TestMain` (so benchmarks get it too).
- **CI** — added a `go vet ./...` step and switched the test step to `go test ./... -race`, so data races and vet issues fail the check; the determinism + fingerprint tests run there as the tile-output gate.

## Tests

All written test-first where they assert new logic: `s57/filter_test.go` (`scaleVisible`), `s57/projection_test.go` (`to3857`/`toTileCoordinate`), `s57/determinism_test.go` (byte determinism), `cmd/s57-tiler/runtile_test.go` (`runTile` panic→error). Existing soundings tests are the safety net for the `ConfigureGDAL` move.

## Verification

`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./... -race -count=1` green · fingerprint unchanged (`b711f2847b6dbf7c`) · benchmarks still run (config applied via `TestMain`).