### PR TITLE
Fix multi-arch Docker build: per-leg Go toolchain + pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,25 @@ FROM ghcr.io/osgeo/gdal:ubuntu-small-3.9.1 AS build
 
 # Build inside the GDAL image so the binary links against the same GDAL it runs
 # against. Use a pinned Go toolchain (overridable) rather than the distro's
-# golang-go, which can lag go.mod's required version. TARGETARCH is provided by
-# buildx for multi-arch builds; it defaults to amd64 for a plain `docker build`.
+# golang-go, which can lag go.mod's required version.
+#
+# TARGETARCH is an automatic platform ARG buildx injects per target leg. Do NOT
+# give it a default: a default value *shadows* buildx's injected value
+# (docker/buildx#510), pinning every leg to one arch. That silently downloaded an
+# amd64 Go toolchain on the arm64 leg, so cgo handed the x86-only `-m64` flag to
+# the native aarch64 gcc ("gcc: unrecognized command-line option '-m64'"). Declare
+# it bare and fall back to the container's native arch (via dpkg) only when it is
+# genuinely empty, e.g. under the legacy DOCKER_BUILDKIT=0 builder.
 ARG GO_VERSION=1.26.0
-ARG TARGETARCH=amd64
+ARG TARGETARCH
+# pkg-config resolves the gdal binding's `#cgo pkg-config: gdal` directive. It used
+# to arrive transitively via golang-go; now that Go is a pinned tarball it must be
+# installed explicitly, or the cgo build fails with "pkg-config: not found".
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential git ca-certificates wget && \
+    apt-get install -y --no-install-recommends build-essential pkg-config git ca-certificates wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO- https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz | tar -C /usr/local -xz
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    wget -qO- "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH=/usr/local/go/bin:$PATH
 
 WORKDIR /app


### PR DESCRIPTION
The arm64 leg of `docker buildx --platform linux/amd64,linux/arm64` failed with `gcc: error: unrecognized command-line option '-m64'`.

Root cause: `ARG TARGETARCH=amd64` gave an automatic platform ARG a default value, which shadows the per-leg value buildx injects (docker/buildx#510). TARGETARCH stayed amd64 on every leg, so the arm64 leg downloaded an amd64 Go toolchain; run under QEMU it defaults GOARCH=amd64 and cgo passed the x86-only `-m64` flag to the container's native aarch64 gcc, which rejects it. This regressed in afbc399, which replaced `apt install golang-go` (always the container-native arch) with a pinned Go tarball keyed on the shadowed TARGETARCH.

Fix: declare `ARG TARGETARCH` bare so buildx's per-leg value is honored, with a `${TARGETARCH:-$(dpkg --print-architecture)}` fallback for the legacy builder (which doesn't inject platform ARGs).

Also re-add pkg-config: the gdal binding builds via `#cgo pkg-config: gdal`. afbc399 dropped golang-go, which had pulled pkg-config in transitively; without it the cgo build fails with "pkg-config: not found" once the toolchain is correct. This was masked by the earlier -m64 error (it aborts compiling stdlib runtime/cgo, before the gdal package is reached).

Verified: arm64 leg now builds end-to-end (correct go1.26.0.linux-arm64 toolchain, cgo + gdal link succeed).